### PR TITLE
Fix remove directory return error

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,7 +26,7 @@ if [ "$1" = 'edgedb-server' ]; then
 	if ! [ "$(ls -A ${EDGEDB_DATADIR})" ]; then
 		shopt -s dotglob
 
-		rm -r /var/run/edgedb/*
+		rm -rf /var/run/edgedb/*
 		echo "Bootstrapping EdgeDB instance..."
 		env EDGEDB_DEBUG_SERVER=1 edgedb-server -b -p5656
 		socket="/var/run/edgedb/.s.EDGEDB.5656"


### PR DESCRIPTION
# PR description

The error will be returned with the return value at the first execution.

It is guessed that rm returns "exit 1" at empty directory.

before

```
$docker run -it --rm -p 5656:5656 -v data:/var/lib/edgedb/data edgedb/edgedb
rm: cannot remove '/var/run/edgedb/*': No such file or directory
```

after

```
$docker build -t edgedb:1.0 --build-arg version=1-alpha1 .
$docker run -it --rm -p 5656:5656 -v data:/var/lib/edgedb/data edgedb:1.0
Bootstrapping EdgeDB instance...
CONFIGURE SYSTEM
CONFIGURE SYSTEM
INFO 1 2019-04-20 09:59:31,814 edb.server: EdgeDB server (1.0.alpha.1) starting.
INFO 1 2019-04-20 09:59:34,229 edb.server: Serving on 0.0.0.0:5656
INFO 1 2019-04-20 09:59:34,229 edb.server: Serving on /run/edgedb/.s.EDGEDB.5656
INFO 1 2019-04-20 09:59:34,230 edb.server: Serving admin on /run/edgedb/.s.EDGEDB.admin.5656
```

# version

```
$docker --version
Docker version 18.09.5, build e8ff056
```

