### PR TITLE
New setup of dockerfile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Run Nightly Tests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  repository_dispatch:
+    types: ["test"]
+  push:
+  pull_request:
+
+jobs:
+
+  nightly-test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@master
+      - name: Install packages
+        run: sudo apt-get install -y bats jq parallel
+      - name: Install edgedb CLI
+        uses: edgedb/setup-edgedb@v1
+        with:
+          cli-version: nightly
+      - name: Run tests
+        run: bats tests/*.bats

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ VOLUME /var/lib/edgedb/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["edgedb-server"]
+CMD ["edgedb-server", "--bind-address=0.0.0.0"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
+set -Exeo pipefail
 
-set -Eeo pipefail
+DIR=/docker-entrypoint.d
 
-if [ "${1:0:1}" = '-' ]; then
+if [[ -z "$_SKIP_ENTRYPOINT" ]] && [[ -d "$DIR" ]]; then
+  /bin/run-parts --verbose "$DIR"
+fi
+
+
+if [[ "${1:0:1}" = '-' ]]; then
 	set -- edgedb-server "$@"
 fi
 
-if [ "${1}" = 'edgedb-server' ] && [ "$(id -u)" = '0' ]; then
-	if [ -n "${EDGEDB_DATADIR}" ]; then
+if [[ "${1}" = 'edgedb-server' ]] && [[ "$(id -u)" = '0' ]]; then
+	if [[ -n "${EDGEDB_DATADIR}" ]]; then
 		mkdir -p "${EDGEDB_DATADIR}"
 		chown -R edgedb "${EDGEDB_DATADIR}"
 		chmod 700 "${EDGEDB_DATADIR}"
@@ -19,61 +25,90 @@ if [ "${1}" = 'edgedb-server' ] && [ "$(id -u)" = '0' ]; then
 		unset EDGEDB_DATADIR
 	fi
 
-	exec gosu edgedb "$BASH_SOURCE" "$@"
+	exec gosu edgedb env _SKIP_ENTRYPOINT=1 "$BASH_SOURCE" "$@"
 fi
 
-if [ "${1}" = 'edgedb-server' -a "$#" -eq 1 ]; then
+if [[ "$1" = 'edgedb-server' ]] && [[ "$2" = "--bind-address=0.0.0.0" ]] && [[ "$#" -eq 2 ]]; then
 	mkdir -p "${EDGEDB_DATADIR}"
 	chown -R "$(id -u)" "${EDGEDB_DATADIR}" 2>/dev/null || :
 	chmod 700 "${EDGEDB_DATADIR}" 2>/dev/null || :
 
-	if ! [ "$(ls -A ${EDGEDB_DATADIR})" ]; then
+	if [[ -z "$(ls -A ${EDGEDB_DATADIR})" ]]; then
 		shopt -s dotglob
+
+        bootstrap_opts=("--port=5656")
+        edgedb_user="${EDGEDB_USER:-edgedb}"
+        edgedb_database="${EDGEDB_DATABASE:-edgedb}"
+        if [[ -e "/edgedb-bootstrap.edgeql" ]]; then
+            bootstrap_opts+=("--bootstrap-script=/edgedb-bootstrap.edgeql")
+        elif [[ -n "$EDGEDB_BOOTSTRAP_COMMAND" ]]; then
+            bootstrap_opts+=("--bootstrap-command=$EDGEDB_BOOTSTRAP_COMMAND")
+        elif [[ -n "$EDGEDB_PASSWORD_HASH" ]]; then
+            if [[ "$edgedb_user" = "edgedb" ]]; then
+                bootstrap_opts+=(--bootstrap-command="ALTER ROLE $edgedb_user { SET password_hash := '$EDGEDB_PASSWORD_HASH'; }")
+            else
+                bootstrap_opts+=(--bootstrap-command="CREATE SUPERUSER ROLE $edgedb_user { SET password_hash := '$EDGEDB_PASSWORD_HASH'; }")
+            fi
+        elif [[ -n "$EDGEDB_PASSWORD" ]]; then
+            if [[ "$edgedb_user" = "edgedb" ]]; then
+                bootstrap_opts+=(--bootstrap-command="ALTER ROLE $edgedb_user { SET password := '$EDGEDB_PASSWORD'; }")
+            else
+                bootstrap_opts+=(--bootstrap-command="CREATE SUPERUSER ROLE $edgedb_user { SET password := '$EDGEDB_PASSWORD'; }")
+            fi
+        fi
 
 		rm -rf /var/run/edgedb/*
 		echo "Bootstrapping EdgeDB instance..."
-		env EDGEDB_DEBUG_SERVER=1 edgedb-server -b -P5656
-		socket="/var/run/edgedb/.s.EDGEDB.5656"
+		edgedb-server "${bootstrap_opts[@]}" &
+        edgedb_pid="$!"
 
-		try=1
-		while [ $try -le 120 ]; do
-			[ -e "${socket}" ] && break
-			try=$(( $try + 1 ))
-			sleep 1
-		done
+        if [[ "$edgedb_database" != edgedb ]]; then
+            first_cmd=(edgedb --wait-until-available=120s --admin -d edgedb create-database $edgedb_database)
+        else
+            first_cmd=(edgedb --wait-until-available=120s --admin query 'SELECT 1')
+        fi
 
-		if [ ! -e "${socket}" ]; then
+		if ! "${first_cmd[@]}"; then
 			echo "ERROR: Server did not start within 120 seconds." >&2
 			rm -r "${EDGEDB_DATADIR}/"*
 			exit 1
 		fi
 
-		edgedb --admin -u edgedb configure \
-			insert Auth --method=Trust --priority=0
-		edgedb --admin -u edgedb configure \
-			set listen_addresses "0.0.0.0"
 
-		pid=$(ps aux | grep 'edgedb-server-5656' | grep -v 'grep' \
-					 | awk '{print $2;}')
+        if [[ -d "/edgedb-bootstrap.d" ]]; then
+            /bin/run-parts --verbose /edgedb-bootstrap.d --regex='\.sh$'
+            # Feeding scripts one by one, so that errors are easier to debug
+            for filename in $(/bin/run-parts --list /edgedb-bootstrap.d --regex='\.edgeql$'); do
+                echo "Bootstrap script $filename"
+                cat $filename | edgedb --admin
+            done
+        fi
 
-		kill "${pid}"
 
-		try=1
-		while [ $try -le 10 ]; do
-			if ! (ps aux | grep 'edgedb-server-5656' \
-						 | grep -v 'grep' >/dev/null); then
-				break
-			fi
-			try=$(( $try + 1 ))
-			sleep 1
-		done
-
-		if (ps aux | grep 'edgedb-server-5656' | grep -v 'grep'); then
+		kill "${edgedb_pid}"
+        shell_pid="$$"
+        (
+            sleep 10;
 			echo "ERROR: Server did not stop within 10 seconds." >&2
-			rm -r "${EDGEDB_DATADIR}/"*
-			exit 1
-		fi
+            kill $shell_pid
+        ) &
+        timeout_pid="$!"
+        wait "${edgedb_pid}"
+        kill "${timeout_pid}"
 	fi
+
+    if [[ -d "/dbschema" ]] && [[ -z "$EDGEDB_SKIP_MIGRATIONS" ]]; then
+        shell_pid="$$"
+        (
+            if ! edgedb --wait-until-available=120s \
+                --admin migrate --schema-dir=/dbschema
+            then
+                echo "ERROR: Migrations failed. Stopping server."
+                kill "$shell_pid"
+            fi
+        ) &
+    fi
 fi
+
 
 exec "$@"

--- a/tests/auth.bats
+++ b/tests/auth.bats
@@ -1,0 +1,113 @@
+containers=()
+
+setup() {
+    slot=$(
+        curl https://packages.edgedb.com/apt/.jsonindexes/stretch.nightly.json \
+        | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
+    docker build -t edgedb/edgedb:latest \
+        --build-arg "version=$slot" --build-arg "subdist=.nightly" \
+        .
+
+}
+
+teardown() {
+    for cont in "${containers[@]}"; do
+        echo "--- CONTAINER: $cont ---"
+        docker logs "$cont"
+    done
+    docker rm -f "${containers[@]}"
+}
+
+@test "new user plain password" {
+    container_id="edb_dock_$(uuidgen)"
+    containers+=($container_id)
+    docker run -d --name=$container_id --publish=5656 \
+        --env=EDGEDB_USER=test1 \
+        --env=EDGEDB_PASSWORD=test2 \
+        edgedb/edgedb:latest
+    port=$(docker inspect "$container_id" \
+        | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
+    output=$(echo test2 | edgedb --wait-until-available=120s -P$port \
+        -u test1 --password-from-stdin \
+        query "SELECT 7+7")
+    run echo "$output"
+    [[ ${lines[-1]} = "14" ]]
+}
+
+@test "new user hashed password" {
+    container_id="edb_dock_$(uuidgen)"
+    containers+=($container_id)
+    docker run -d --name=$container_id --publish=5656 \
+        --env=EDGEDB_USER=test1 \
+        --env='EDGEDB_PASSWORD_HASH=SCRAM-SHA-256$4096:rEQ2xuv6ASCA61VMaqU9yg==$uvda3+u+zewd/GvbIofDjk5EEReNJ0KRhLX0001bVRQ=:sdF5jXfPMnM9GNu+JC39fV4Pa5oZEULEm8cdDRZMJDw=' \
+        edgedb/edgedb:latest
+    port=$(docker inspect "$container_id" \
+        | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
+    output=$(echo test3 | edgedb --wait-until-available=120s -P$port \
+        -u test1 --password-from-stdin \
+        query "SELECT 7*3")
+    run echo "$output"
+    [[ ${lines[-1]} = "21" ]]
+}
+
+@test "create role manually" {
+    container_id="edb_dock_$(uuidgen)"
+    containers+=($container_id)
+    docker run -d --name=$container_id --publish=5656 \
+        --env=EDGEDB_BOOTSTRAP_COMMAND="CREATE SUPERUSER ROLE test1 { SET password := 'test4'; };" \
+        edgedb/edgedb:latest
+    port=$(docker inspect "$container_id" \
+        | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
+    output=$(echo test4 | edgedb --wait-until-available=120s -P$port \
+        -u test1 --password-from-stdin \
+        query "SELECT 7*4")
+    run echo "$output"
+    [[ ${lines[-1]} = "28" ]]
+}
+
+@test "edgedb: plain password" {
+    container_id="edb_dock_$(uuidgen)"
+    containers+=($container_id)
+    docker run -d --name=$container_id --publish=5656 \
+        --env=EDGEDB_PASSWORD=test2 \
+        edgedb/edgedb:latest
+    port=$(docker inspect "$container_id" \
+        | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
+    output=$(echo test2 | edgedb --wait-until-available=120s -P$port \
+        --password-from-stdin \
+        query "SELECT 7+7")
+    run echo "$output"
+    [[ ${lines[-1]} = "14" ]]
+}
+
+@test "edgedb: hashed password" {
+    container_id="edb_dock_$(uuidgen)"
+    containers+=($container_id)
+    docker run -d --name=$container_id --publish=5656 \
+        --env='EDGEDB_PASSWORD_HASH=SCRAM-SHA-256$4096:rEQ2xuv6ASCA61VMaqU9yg==$uvda3+u+zewd/GvbIofDjk5EEReNJ0KRhLX0001bVRQ=:sdF5jXfPMnM9GNu+JC39fV4Pa5oZEULEm8cdDRZMJDw=' \
+        edgedb/edgedb:latest
+    port=$(docker inspect "$container_id" \
+        | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
+    output=$(echo test3 | edgedb --wait-until-available=120s -P$port \
+        --password-from-stdin \
+        query "SELECT 7*3")
+    run echo "$output"
+    [[ ${lines[-1]} = "21" ]]
+}
+
+@test "named database" {
+    container_id="edb_dock_$(uuidgen)"
+    containers+=($container_id)
+    docker run -d --name=$container_id --publish=5656 \
+        --env=EDGEDB_DATABASE=hello \
+        --env=EDGEDB_USER=test1 \
+        --env=EDGEDB_PASSWORD=test5 \
+        edgedb/edgedb:latest
+    port=$(docker inspect "$container_id" \
+        | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
+    output=$(echo test5 | edgedb --wait-until-available=120s -P$port \
+        -d hello -u test1 --password-from-stdin \
+        query "SELECT 7+7")
+    run echo "$output"
+    [[ ${lines[-1]} = "14" ]]
+}

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -1,0 +1,38 @@
+containers=()
+
+setup() {
+    slot=$(
+        curl https://packages.edgedb.com/apt/.jsonindexes/stretch.nightly.json \
+        | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
+    docker build -t edgedb/edgedb:latest \
+        --build-arg "version=$slot" --build-arg "subdist=.nightly" \
+        .
+    docker build -t edgedb-test:bootstrap tests/bootstrap
+}
+
+teardown() {
+    for cont in "${containers[@]}"; do
+        echo "--- CONTAINER: $cont ---"
+        docker logs "$cont"
+    done
+    if [[ ${#containers[@]} ]]; then
+        docker rm -f "${containers[@]}"
+    fi
+}
+
+@test "full bootstrap" {
+    container_id="edb_dock_$(uuidgen)"
+    containers+=($container_id)
+    # The user declared here is ignored
+    docker run -d --name=$container_id --publish=5656 edgedb-test:bootstrap
+    port=$(docker inspect "$container_id" \
+        | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
+    output=$(echo password2 | edgedb --wait-until-available=120s -P$port \
+        -u user1 --password-from-stdin \
+        --tab-separated query "SELECT Bootstrap.name ORDER BY Bootstrap.name")
+    echo "$output"
+    run echo "$output"
+    [[ ${lines[0]} = "01-shell script" ]]
+    [[ ${lines[1]} = "02-edgeql file" ]]
+    [[ ${lines[2]} = "03-edgeql file" ]]
+}

--- a/tests/bootstrap/Dockerfile
+++ b/tests/bootstrap/Dockerfile
@@ -1,0 +1,3 @@
+FROM edgedb/edgedb:latest
+COPY /edgedb-bootstrap.edgeql /
+COPY /edgedb-bootstrap.d/* /edgedb-bootstrap.d/

--- a/tests/bootstrap/edgedb-bootstrap.d/01.sh
+++ b/tests/bootstrap/edgedb-bootstrap.d/01.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+edgedb --admin query "INSERT Bootstrap { name := '01-shell script' }"

--- a/tests/bootstrap/edgedb-bootstrap.d/02.edgeql
+++ b/tests/bootstrap/edgedb-bootstrap.d/02.edgeql
@@ -1,0 +1,1 @@
+INSERT Bootstrap { name := '02-edgeql file' }

--- a/tests/bootstrap/edgedb-bootstrap.d/03.edgeql
+++ b/tests/bootstrap/edgedb-bootstrap.d/03.edgeql
@@ -1,0 +1,1 @@
+INSERT Bootstrap { name := '03-edgeql file' }

--- a/tests/bootstrap/edgedb-bootstrap.edgeql
+++ b/tests/bootstrap/edgedb-bootstrap.edgeql
@@ -1,0 +1,4 @@
+CREATE SUPERUSER ROLE user1 { SET password := 'password2'; };
+CREATE TYPE Bootstrap {
+    CREATE PROPERTY name -> str;
+};

--- a/tests/schema.bats
+++ b/tests/schema.bats
@@ -1,0 +1,43 @@
+containers=()
+
+setup() {
+    slot=$(
+        curl https://packages.edgedb.com/apt/.jsonindexes/stretch.nightly.json \
+        | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
+    docker build -t edgedb/edgedb:latest \
+        --build-arg "version=$slot" --build-arg "subdist=.nightly" \
+        .
+    docker build -t edgedb-test:schema tests/schema
+}
+
+teardown() {
+    for cont in "${containers[@]}"; do
+        echo "--- CONTAINER: $cont ---"
+        docker logs "$cont"
+    done
+    if [[ ${#containers[@]} ]]; then
+        docker rm -f "${containers[@]}"
+    fi
+}
+
+@test "applying schema" {
+    container_id="edb_dock_$(uuidgen)"
+    containers+=($container_id)
+    # The user declared here is ignored
+    docker run -d --name=$container_id --publish=5656 \
+        --env=EDGEDB_USER=user1 \
+        --env=EDGEDB_PASSWORD=password2 \
+        edgedb-test:schema
+    port=$(docker inspect "$container_id" \
+        | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
+    # ensure started
+    echo password2 | edgedb --wait-until-available=120s -P$port \
+        -u user1 --password-from-stdin \
+        --tab-separated query "SELECT 1"
+    # wait until migrations are complete
+    sleep 3
+    # now check that this worked
+    echo password2 | edgedb --wait-until-available=120s -P$port \
+        -u user1 --password-from-stdin \
+        --tab-separated query "INSERT Item { name := 'hello' }"
+}

--- a/tests/schema/Dockerfile
+++ b/tests/schema/Dockerfile
@@ -1,0 +1,2 @@
+FROM edgedb/edgedb:latest
+COPY /dbschema /dbschema

--- a/tests/schema/dbschema/default.esdl
+++ b/tests/schema/dbschema/default.esdl
@@ -1,0 +1,5 @@
+module default {
+    type Item {
+        required property name -> str;
+    };
+};

--- a/tests/schema/dbschema/migrations/00001.edgeql
+++ b/tests/schema/dbschema/migrations/00001.edgeql
@@ -1,0 +1,7 @@
+CREATE MIGRATION m1gcgrb7grg2zfq764refma5fevmfumvok5hy2qwnljb7i3qhnjz2a
+    ONTO initial
+{
+  CREATE TYPE default::Item {
+      CREATE REQUIRED PROPERTY name -> std::str;
+  };
+};


### PR DESCRIPTION
This is largely untested for now.

1. Add support of docker-entrypoints.d (fixes #3). Scripts are run by
   a user passed to docker (root by default).
2. If `/edgedb-bootstrap.edgeql` exists, use it as `--bootstrap-script`
3. Else, if `EDGEB_BOOTSTRAP_COMMAND` exists, pass it as `--bootstrap-command`
4. Else, if `EDGEDB_PASSWORD_HASH` exists, create `EDGEDB_USER` or set
   that password for user `edgedb` (uses encoded password)
5. Else, if `EDGEDB_PASSWORD` exists, create `EDGEDB_USER` or set
   password (this is to share settings in docker-compose.yaml easier)
6. If `EDGEDB_DATABASE` is not `edgedb` create that database
7. Run all `/edgedb-bootstrap/*.sh` scripts after configuration above
   (and before restarting the database). Scripts are run as `edgedb`
   user if container is run by root.
8. Execute all `/edgedb-bootstrap/*.edgeql` scripts, all of them are
   executed in the context of `EDGEDB_DATABASE`.
7. If `/dbschema` exists. Run `edgedb migrate` as part of script.
   
 It's largely untested now. Will be testing it tomorrow.