### PR TITLE
Rewrite docker-entrypoint.sh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 /.vscode
+/.editorconfig

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sh]
+indent_size = 2
+indent_style = space

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,6 @@ RUN set -ex; export DEBIAN_FRONTEND=noninteractive; \
 
 ENV LANG en_US.utf8
 ENV VERSION ${version}
-ENV EDGEDB_DATADIR /var/lib/edgedb/data
 
 EXPOSE 5656
 
@@ -57,4 +56,4 @@ VOLUME /var/lib/edgedb/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["edgedb-server", "--bind-address=0.0.0.0"]
+CMD ["edgedb-server"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,192 @@
-Official Dockerfile for EdgeDB
-==============================
+# Official Dockerfile for EdgeDB Server
 
-To build, run:
+## What is EdgeDB?
 
-```bash
-$ docker build -t edgedb:<edgedbver> --build-arg version=<edgedbver> .
+EdgeDB is an **open-source** object-relational database built on top of
+PostgreSQL. The goal of EdgeDB is to _empower_ its users to build safe
+and efficient software with less effort.
+
+EdgeDB features:
+
+- strict, strongly typed schema;
+- powerful and expressive query language;
+- rich standard library;
+- built-in support for schema migrations;
+- native GraphQL support.
+
+See [edgedb.com](https://www.edgedb.com/) and the
+[documentation](https://www.edgedb.com/docs/) for more information about
+EdgeDB and how to get started. This README contains information specifically
+on how to use the EdgeDB server Docker image.
+
+## When to use this image
+
+This image is primarily intended to be used directly when there is a
+requirement to use Docker containers, such as in production, or in a
+development setup that involves multiple containers orchestrated by
+Docker Compose or a similar tool. Otherwise, using the `edgedb server`
+CLI on the host system is the recommended way to install and run
+EdgeDB servers.
+
+## How to use this image
+
+The simplest way to run the image (without data persistence) is this:
+
+```shell
+$ docker run --name edgedb -e EDGEDB_PASSWORD=secret -d edgedb/edgedb
 ```
 
-Where `<edgedbver>` is the version of EdgeDB available for Debian 9.
+See the [Customization](#customization) section below for the meaning of
+the `EDGEDB_PASSWORD` variable and other options.
 
-The container exposes the TCP/IP port 5656, and the `/var/lib/edgedb/data`
-as the persistent data volume.
+Now, to open an interactive shell to the database instance run this:
+
+```
+$ docker run -it --rm --link=edgedb edgedb/edgedb-cli -H edgedb --password
+```
+
+When the CLI prompts for a password, enter the value passed in the
+`EDGEDB_PASSWORD` variable when starting the server container.
+
+## Data Persistence
+
+If you want the contents of the database to survive container restarts,
+you must mount a persistent volume at the path specified by
+`EDGEDB_DATADIR` (`/var/lib/edgedb/data`) by default.  For example:
+
+```shell
+$ docker run \
+    --name edgedb -e EDGEDB_PASSWORD=secret \
+    -v /my/data/directory:/var/lib/edgedb/data \
+    -d edgedb/edgedb
+```
+
+Note that on Windows you must use a Docker volume instead:
+
+```shell
+$ docker volume create --name=edgedb-data
+$ docker run \
+    --name edgedb -e EDGEDB_PASSWORD=secret \
+    -v edgedb-data:/var/lib/edgedb/data \
+    -d edgedb/edgedb
+```
+
+It is also possible to run an `edgedb` container on a remote PostgreSQL
+cluster specified by `EDGEDB_POSTGRES_DSN`.  See below for details.
+
+## Schema Migrations
+
+A derived image may include application schema and migrations in
+`/dbschema`, in which case the container will attempt to apply the
+schema migrations found in `/dbschema/migrations`, unless
+the `EDGEDB_SKIP_MIGRATIONS` environment variable is set.
+
+## Customization
+
+The behavior of the `edgedb` image can be customized via environment
+variables and initialization scripts.
+
+### Initial container setup
+
+When an `edgedb` container starts on the specified data directory or remote
+Postgres cluster for the first time, initial instance setup is performed.
+This is called the _bootstrap phase_.
+
+The following environment variables affect the bootstrap only and have no
+effect on subsequent container runs. The `_FILE` variants of the variables
+allow passing the value via a file mounted inside a container.
+
+#### `EDGEDB_PASSWORD`, `EDGEDB_PASSWORD_FILE`
+
+Determines the password used for the default superuser account.
+
+#### `EDGEDB_PASSWORD_HASH`, `EDGEDB_PASSWORD_HASH_FILE`
+
+A variant of `EDGEDB_PASSWORD`, where the specified value is a hashed password
+verifier instead of plain text.
+
+#### `EDGEDB_USER`, `EDGEDB_USER_FILE`
+
+Optionally specifies the name of the default superuser account. Defaults to
+`edgedb` if not specified.
+
+#### `EDGEDB_DATABASE`, `EDGEDB_DATABASE_FILE`
+
+Optionally specifies the name of a default database that is created during
+bootstrap. Defaults to `edgedb` if not specified.
+
+#### `EDGEDB_AUTH_METHOD`
+
+Optionally specifies the authentication method used by the server instance.
+Supported values are `"scram"` (the default) and `"trust"`.  When set to
+`"trust"`, the database will allow complete unauthenticated access for all
+who have access to the database port.  In this case the `EDGEDB_PASSWORD`
+(or equivalent) setting is not required.
+
+Use at your own risk and only for testing.
+
+#### `EDGEDB_BOOTSTRAP_COMMAND`, `EDGEDB_BOOTSTRAP_SCRIPT_FILE`
+
+Specifies one or more EdgeQL statements to run at bootstrap. If specified,
+overrides `EDGEDB_PASSWORD`, `EDGEDB_PASSWORD_HASH`, `EDGEDB_USER` and
+`EDGEDB_DATABASE`. Useful to fine-tune initial user and database creation,
+and other initial setup. If neither the `EDGEDB_BOOTSTRAP_COMMAND` variable
+or the `EDGEDB_BOOTSTRAP_SCRIPT_FILE` are explicitly specified, the container
+will look for the presence of `/edgedb-bootstrap.edgeql` in the container
+(which can be placed in a derived image).
+
+#### Custom scripts in `/edgedb-bootstrap.d/
+
+To perform additional initialization, a derived image may include one ore
+more `*.edgeql`, or `*.sh` scripts, which are executed in addition to and
+_after_ the initialization specified by the environment variables above
+or the `/edgedb-bootstrap.edgeql` script.
+
+### Runtime Options
+
+Unlike options listed in the [Initial container setup](#initial-container-setup)
+section above, the configuration documented below applies to all container
+invocations.  It can be specified either as environment variables or
+command-line arguments.
+
+#### `EDGEDB_PORT`, `--port`
+
+Specifies the network port on which EdgeDB will listen inside the container.
+The default is `5656`.  This usually doesn't need to be changed unless you
+run in `host` networking mode.
+
+#### `EDGEDB_BIND_ADDRESS`, `--bind-address`
+
+Specifies the network interface on which EdgeDB will listen inside the
+container.  The default is `0.0.0.0`, which means all interfaces.  This
+usually doesn't need to be changed unless you run in `host` networking mode.
+
+#### `EDGEDB_DATADIR`, `--data-dir`
+
+Specifies a path within the container in which the database files are located.
+Defaults to `/var/run/edgedb/data`.  The container needs to be able to
+change the ownership of the mounted directory to `edgedb`.  Cannot be specified
+at the same time with `EDGEDB_POSTGRES_DSN`.
+
+#### `EDGEDB_POSTGRES_DSN`, `EDGEDB_POSTGRES_DSN_FILE`, `--postgres-dsn`
+
+Specifies a PostgreSQL connection string in the
+[URI format](https://www.postgresql.org/docs/13/libpq-connect.html#id-1.7.3.8.3.6).
+If set, the PostgreSQL cluster specified by the URI is used instead of the
+builtin PostgreSQL server.  Cannot be specified at the same time with
+`EDGEDB_DATADIR`.
+
+#### `EDGEDB_RUNSTATE_DIR`, `--runstate-dir`
+
+Specifies a path within the container in which EdgeDB will place its Unix
+socket and other transient files.
+
+#### `EDGEDB_EXTRA_ARGS`, `--extra-arg, ...`
+
+Extra arguments to be passed to EdgeDB server.
+
+#### Custom scripts in `/docker-entrypoint.d/`
+
+To perform additional initialization, a derived image may include one ore
+more executable files in `/docker-entrypoint.d/`, which will get executed
+by the container entrypoint _before_ any other processing takes place.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,117 +1,604 @@
 #!/usr/bin/env bash
-set -Eeo pipefail
-if [[ -n "$EDGEDB_DOCKER_TRACE" ]]; then
-    set -x
-fi
 
-DIR=/docker-entrypoint.d
+# This file is intended to be able to be sourced by another shell script
+# without any side effects.  Put all shell-modifying code into
+# edbdocker_main() below.
 
-if [[ -z "$_SKIP_ENTRYPOINT" ]] && [[ -d "$DIR" ]]; then
-  /bin/run-parts --verbose "$DIR"
-fi
+edbdocker_main() {
+  set -Eeo pipefail
+  shopt -s dotglob
+  if [ -n "$EDGEDB_DOCKER_TRACE" ]; then
+      set -x
+  fi
 
+  # docker run edgedb/edgedb --arg
+  if [ "${1:0:1}" = '-' ]; then
+    set -- edgedb-server "$@"
+  fi
 
-if [[ "${1:0:1}" = '-' ]]; then
-	set -- edgedb-server "$@"
-fi
+  edbdocker_parse_args "$@"
 
-if [[ "${1}" = 'edgedb-server' ]] && [[ "$(id -u)" = '0' ]]; then
-	if [[ -n "${EDGEDB_DATADIR}" ]]; then
-		mkdir -p "${EDGEDB_DATADIR}"
-		chown -R edgedb "${EDGEDB_DATADIR}"
-		chmod 700 "${EDGEDB_DATADIR}"
-
-		mkdir -p /var/run/edgedb
-		chown -R edgedb /var/run/edgedb
-		chmod 775 /var/run/edgedb
-	else
-		unset EDGEDB_DATADIR
-	fi
-
-	exec gosu edgedb env _SKIP_ENTRYPOINT=1 "$BASH_SOURCE" "$@"
-fi
-
-if [[ "$1" = 'edgedb-server' ]] && [[ "$2" = "--bind-address=0.0.0.0" ]] && [[ "$#" -eq 2 ]]; then
-	mkdir -p "${EDGEDB_DATADIR}"
-	chown -R "$(id -u)" "${EDGEDB_DATADIR}" 2>/dev/null || :
-	chmod 700 "${EDGEDB_DATADIR}" 2>/dev/null || :
-
-	if [[ -z "$(ls -A ${EDGEDB_DATADIR})" ]]; then
-		shopt -s dotglob
-
-        bootstrap_opts=("--port=5656")
-        edgedb_user="${EDGEDB_USER:-edgedb}"
-        edgedb_database="${EDGEDB_DATABASE:-edgedb}"
-        if [[ -e "/edgedb-bootstrap.edgeql" ]]; then
-            bootstrap_opts+=("--bootstrap-script=/edgedb-bootstrap.edgeql")
-        elif [[ -n "$EDGEDB_BOOTSTRAP_COMMAND" ]]; then
-            bootstrap_opts+=("--bootstrap-command=$EDGEDB_BOOTSTRAP_COMMAND")
-        elif [[ -n "$EDGEDB_PASSWORD_HASH" ]]; then
-            if [[ "$edgedb_user" = "edgedb" ]]; then
-                bootstrap_opts+=(--bootstrap-command="ALTER ROLE $edgedb_user { SET password_hash := '$EDGEDB_PASSWORD_HASH'; }")
-            else
-                bootstrap_opts+=(--bootstrap-command="CREATE SUPERUSER ROLE $edgedb_user { SET password_hash := '$EDGEDB_PASSWORD_HASH'; }")
-            fi
-        elif [[ -n "$EDGEDB_PASSWORD" ]]; then
-            if [[ "$edgedb_user" = "edgedb" ]]; then
-                bootstrap_opts+=(--bootstrap-command="ALTER ROLE $edgedb_user { SET password := '$EDGEDB_PASSWORD'; }")
-            else
-                bootstrap_opts+=(--bootstrap-command="CREATE SUPERUSER ROLE $edgedb_user { SET password := '$EDGEDB_PASSWORD'; }")
-            fi
-        fi
-
-		rm -rf /var/run/edgedb/*
-		echo "Bootstrapping EdgeDB instance..."
-		edgedb-server "${bootstrap_opts[@]}" &
-        edgedb_pid="$!"
-
-        if [[ "$edgedb_database" != edgedb ]]; then
-            first_cmd=(edgedb --wait-until-available=120s --admin -d edgedb create-database $edgedb_database)
-        else
-            first_cmd=(edgedb --wait-until-available=120s --admin query 'SELECT 1')
-        fi
-
-		if ! "${first_cmd[@]}"; then
-			echo "ERROR: Server did not start within 120 seconds." >&2
-			rm -r "${EDGEDB_DATADIR}/"*
-			exit 1
-		fi
+  if [ "$_EDBDOCKER_SHOW_HELP" = "1" -o "$1" != "edgedb-server" ]; then
+    # `edgedb-server --help` or any other command goes straight to execution.
+    exec "$@"
+  else
+    edbdocker_run_server "$@"
+  fi
+}
 
 
-        if [[ -d "/edgedb-bootstrap.d" ]]; then
-            /bin/run-parts --verbose /edgedb-bootstrap.d --regex='\.sh$'
-            # Feeding scripts one by one, so that errors are easier to debug
-            for filename in $(/bin/run-parts --list /edgedb-bootstrap.d --regex='\.edgeql$'); do
-                echo "Bootstrap script $filename"
-                cat $filename | edgedb --admin
-            done
-        fi
+# Parse server arguments and populate environment variables accordingly.
+# Arguments override environment variables.
+edbdocker_parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        export _EDBDOCKER_SHOW_HELP="1"
+        shift
+        ;;
+      -D|--data-dir)
+        _edbdocker_parse_arg "EDGEDB_DATADIR" "$1" "$2"
+        shift 2
+        ;;
+      --data-dir=*)
+        export EDGEDB_DATADIR="${1#*=}"
+        shift
+        ;;
+      --runstate-dir)
+        _edbdocker_parse_arg "EDGEDB_RUNSTATE_DIR" "$1" "$2"
+        shift 2
+        ;;
+      --runstate-dir=*)
+        export EDGEDB_RUNSTATE_DIR="${1#*=}"
+        shift
+        ;;
+      --postgres-dsn)
+        _edbdocker_parse_arg "EDGEDB_POSTGRES_DSN" "$1" "$2"
+        shift 2
+        ;;
+      --postgres-dsn=*)
+        export EDGEDB_POSTGRES_DSN="${1#*=}"
+        shift
+        ;;
+      -P|--port)
+        _edbdocker_parse_arg "EDGEDB_PORT" "$1" "$2"
+        shift 2
+        ;;
+      --port=*)
+        export EDGEDB_PORT="${1#*=}"
+        shift
+        ;;
+      -I|--bind-address)
+        _edbdocker_parse_arg "EDGEDB_BIND_ADDRESS" "$1" "$2"
+        shift 2
+        ;;
+      --bind-address=*)
+        export EDGEDB_BIND_ADDRESS="${1#*=}"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+}
 
 
-		kill "${edgedb_pid}"
-        shell_pid="$$"
-        (
-            sleep 10;
-			echo "ERROR: Server did not stop within 10 seconds." >&2
-            kill $shell_pid
-        ) &
-        timeout_pid="$!"
-        wait "${edgedb_pid}"
-        kill "${timeout_pid}"
-	fi
+_edbdocker_parse_arg() {
+  local var
+  local opt
+  local val
 
-    if [[ -d "/dbschema" ]] && [[ -z "$EDGEDB_SKIP_MIGRATIONS" ]]; then
-        shell_pid="$$"
-        (
-            if ! edgedb --wait-until-available=120s \
-                --admin migrate --schema-dir=/dbschema
-            then
-                echo "ERROR: Migrations failed. Stopping server."
-                kill "$shell_pid"
-            fi
-        ) &
+  var="$1"
+  opt="$2"
+  val="$3"
+
+  if [ -n "$val" ] && [ "${val:0:1}" != "-" ]; then
+    export "$var"="$val"
+  else
+    local msg
+    msg=(
+      "ERROR: The argument '${opt} <val>' requires a value, but none was supplied."
+      "       Try '--help' for more information."
+    )
+    edbdocker_die "${msg[@]}"
+  fi
+}
+
+
+# The real main().  Takes full server command line, performs instance
+# bootstrap, runs migrations and finally executes the edgedb-server.
+# Note: `edbdocker_parse_args` must be called before calling
+#       `edbdocker_run_server`.
+# Usage: edbdocker_run_server edgedb-server --arg=val --arg1=val2 ...
+edbdocker_run_server() {
+  if [ -z "$_EDBDOCKER_RESTARTED" ]; then
+    if [ -d "/docker-entrypoint.d" ]; then
+      /bin/run-parts --verbose "/docker-entrypoint.d"
     fi
+  fi
+
+  edbdocker_setup_env
+  edbdocker_ensure_dirs
+
+  if [ "$(id -u)" = "0" ]; then
+    # if we are root, restart as "edgedb"
+    exec gosu edgedb env _EDBDOCKER_RESTARTED=1 "$BASH_SOURCE" "$@"
+  fi
+
+  if [ -n "${EDGEDB_DATADIR:-}" ]; then
+    if [ -z "$(ls -A "${EDGEDB_DATADIR}")" ]; then
+      edbdocker_bootstrap_instance
+    fi
+  elif ! edbdocker_remote_cluster_is_initialized "${EDGEDB_POSTGRES_DSN}"; then
+    edbdocker_bootstrap_instance
+  fi
+
+  edbdocker_run_migrations
+
+  local server_args=(
+    --bind-address="$EDGEDB_BIND_ADDRESS"
+    --port="$EDGEDB_PORT"
+  )
+
+  if [ -n "${EDGEDB_POSTGRES_DSN}" ]; then
+    server_args+=( --postgres-dsn="${EDGEDB_POSTGRES_DSN}" )
+  else
+    server_args+=( --data-dir="${EDGEDB_DATADIR}" )
+  fi
+
+  exec "$@" ${EDGEDB_EXTRA_ARGS} "${server_args[@]}"
+}
+
+
+# Populate important environment variables and make sure they are sane.
+edbdocker_setup_env() {
+  : ${EDGEDB_PORT:="5656"}
+  : ${EDGEDB_BIND_ADDRESS:="0.0.0.0"}
+  : ${EDGEDB_AUTH_METHOD:="scram"}
+
+  edbdocker_lookup_env_var "EDGEDB_USER" "edgedb"
+  edbdocker_lookup_env_var "EDGEDB_DATABASE" "edgedb"
+  edbdocker_lookup_env_var "EDGEDB_PASSWORD"
+  edbdocker_lookup_env_var "EDGEDB_PASSWORD_HASH"
+  edbdocker_lookup_env_var "EDGEDB_POSTGRES_DSN"
+
+  if [ -n "${EDGEDB_DATADIR:-}" ] && [ -n "${EDGEDB_POSTGRES_DSN:-}" ]; then
+    edbdocker_die "ERROR: EDGEDB_DATADIR and EDGEDB_POSTGRES_DSN are mutually exclusive, but both are set"
+  elif [ -z "${EDGEDB_POSTGRES_DSN}" ]; then
+    export EDGEDB_DATADIR="${EDGEDB_DATADIR:-/var/lib/edgedb/data}"
+  fi
+
+  if [ -n "${EDGEDB_PASSWORD:-}" ] && [ -n "${EDGEDB_PASSWORD_HASH:-}" ]; then
+    edbdocker_die "ERROR: EDGEDB_PASSWORD and EDGEDB_PASSWORD_PASH are mutually exclusive, but both are set"
+  fi
+
+  if [ -n "${EDGEDB_BOOTSTRAP_SCRIPT_FILE:-}" ] && [ -n "${EDGEDB_BOOTSTRAP_COMMAND:-}" ]; then
+    edbdocker_die "ERROR: EDGEDB_BOOTSTRAP_SCRIPT_FILE and EDGEDB_BOOTSTRAP_COMMAND are mutually exclusive, but both are set"
+  fi
+
+  export EDGEDB_RUNSTATE_DIR="${EDGEDB_RUNSTATE_DIR:-/run/edgedb}"
+}
+
+
+# Resolve the value of the specified variable.
+# Usage: edbdocker_lookup_env_var VARNAME [default]
+# The function looks for $VARNAME in the environment block directly,
+# and also tries to read the value from ${VARNAME}_FILE, if set.
+# For example, `edbdocker_lookup_env_var EDGEDB_PASSWORD foo` would
+# look for $EDGEDB_PASSWORD, the file specified by $EDGEDB_PASSWORD_FILE,
+# and if neither is set, default to 'foo'.
+edbdocker_lookup_env_var() {
+  local var="$1"
+  local file_var="${var}_FILE"
+  local deflt="${2:-}"
+  local val="$deflt"
+  local var_val="${!var:-}"
+  local file_var_val="${!file_var:-}"
+
+  if [ -n "${var_val}" ] && [ -n "${file_var_val}" ]; then
+    edbdocker_die \
+      "ERROR: ${var} and ${file_var} are exclusive, but both are set."
+  fi
+
+  if [ -n "${var_val}" ]; then
+    val="${var_val}"
+  elif [ "${file_var_val}" ]; then
+    if [ -e "${file_var_val}" ]; then
+      val="$(< "${file_var_val}")"
+    else
+      edbdocker_die \
+        "ERROR: the file specified by ${file_var} (${file_var_val}) does not exist."
+    fi
+  fi
+
+  export "$var"="$val"
+  unset "$file_var"
+}
+
+
+# Create directories required by EdgeDB server and set correct permissions
+# if running as root.
+edbdocker_ensure_dirs() {
+  if [ -n "${EDGEDB_DATADIR}" ]; then
+    mkdir -p "${EDGEDB_DATADIR}"
+    chmod 700 "${EDGEDB_DATADIR}" || :
+
+    if [ "$(id -u)" = "0" ]; then
+      chown -R "edgedb" "${EDGEDB_DATADIR}"
+    fi
+  else
+    unset EDGEDB_DATADIR
+  fi
+
+  mkdir -p "${EDGEDB_RUNSTATE_DIR}"
+  chmod 775 "${EDGEDB_RUNSTATE_DIR}"
+
+  if [ "$(id -u)" = "0" ]; then
+    chown -R "edgedb" "${EDGEDB_RUNSTATE_DIR}"
+  fi
+}
+
+
+# Check if the specified Postgres DSN contains an initialized EdgeDB instance.
+# Returns 0 if so, 1 otherwise.
+edbdocker_remote_cluster_is_initialized() {
+  local pg_dsn="$1"
+  local psql="$(dirname "$(readlink -f /usr/bin/edgedb-server)")/psql"
+
+  if echo "\\l" \
+     | "$psql" "${pg_dsn}" 2>/dev/null \
+     | grep "__edgedbsys__" >/dev/null
+  then
+    return 0
+  else
+    # Either psql couldn't connect to the specified DSN, or EdgeDB
+    # is not bootstrapped on the target cluster.  In the former case,
+    # bootstrap will likely fail with an informative error.
+    return 1
+  fi
+}
+
+
+# Bootstrap the configured EdgeDB instance.  Expects either
+# EDGEDB_DATADIR or EDGEDB_POSTGRES_DSN to be set in the environment.
+# Optionally takes extra server arguments.  Bootstrap is performed by
+# a temporary edgedb-server process that gets started on a random port
+# and is shut down once bootstrap is complete.
+#
+# Usage: `EDGEDB_DATADIR=/foo/bar edbdocker_bootstrap_instance --arg=val`
+edbdocker_bootstrap_instance() {
+  local bootstrap_cmd
+  local bootstrap_opts
+  local server_info
+  local server_pid
+  local conn_opts
+
+  bootstrap_opts=( "$@" )
+
+  if [ -n "${EDGEDB_POSTGRES_DSN}" ]; then
+    bootstrap_opts+=(--postgres-dsn="${EDGEDB_POSTGRES_DSN}")
+  else
+    bootstrap_opts+=(--data-dir="${EDGEDB_DATADIR}")
+  fi
+
+  if [ -n "${EDGEDB_BOOTSTRAP_SCRIPT_FILE}" ]; then
+    if ! [ -e "${EDGEDB_BOOTSTRAP_SCRIPT_FILE}" ]; then
+      edbdocker_die "ERROR: the file specified by EDGEDB_BOOTSTRAP_SCRIPT_FILE (${EDGEDB_BOOTSTRAP_SCRIPT_FILE}) does not exist."
+    else
+      bootstrap_opts+=(--bootstrap-script="${EDGEDB_BOOTSTRAP_SCRIPT_FILE}")
+    fi
+
+  elif [ -n "${EDGEDB_BOOTSTRAP_COMMAND}" ]; then
+    bootstrap_opts+=(--bootstrap-command="${EDGEDB_BOOTSTRAP_COMMAND}")
+
+  elif [ -e "/edgedb-bootstrap.edgeql" ]; then
+    bootstrap_opts+=(--bootstrap-script="/edgedb-bootstrap.edgeql")
+
+  else
+    if [ -z "${bootstrap_cmd}" ]; then
+      if [ -n "${EDGEDB_PASSWORD_HASH:-}" ]; then
+        if [ "$EDGEDB_USER" = "edgedb" ]; then
+          bootstrap_cmd="ALTER ROLE ${EDGEDB_USER} { SET password_hash := '${EDGEDB_PASSWORD_HASH}'; }"
+        else
+          bootstrap_cmd="CREATE SUPERUSER ROLE ${EDGEDB_USER} { SET password_hash := '${EDGEDB_PASSWORD_HASH}'; }"
+        fi
+      elif [ -n "$EDGEDB_PASSWORD" ]; then
+        if [[ "$EDGEDB_USER" = "edgedb" ]]; then
+          bootstrap_cmd="ALTER ROLE ${EDGEDB_USER} { SET password := '${EDGEDB_PASSWORD}'; }"
+        else
+          bootstrap_cmd="CREATE SUPERUSER ROLE ${EDGEDB_USER} { SET password := '${EDGEDB_PASSWORD}'; }"
+        fi
+      elif [ "${EDGEDB_AUTH_METHOD:-}" = "trust" ]; then
+        bootstrap_cmd="CONFIGURE SYSTEM INSERT Auth {priority := 0, method := (INSERT Trust)};"
+        msg=(
+          "=============================================================== "
+          "WARNING: EDGEDB_AUTH_METHOD is set to 'trust'.  This will allow "
+          "         unauthenticated access to this EdgeDB instance for all "
+          "         who have access to the database port! This might       "
+          "         include other containers or processes on the same host "
+          "         and, if port ${EDGEDB_PORT} is bound to an accessible  "
+          "         interface on the host, other machines on the network.  "
+          "                                                                "
+          "         Use only for TESTING in a known environment without    "
+          "         sensitive data.  It is strongly recommended to use     "
+          "         password authentication via the EDGEDB_PASSWORD or     "
+          "         EDGEDB_PASSWORD_HASH environment variables.            "
+          "=============================================================== "
+        )
+        edbdocker_log "${msg[@]}"
+      else
+        msg=(
+          "ERROR: the EdgeDB instance at the specified location is not     "
+          "       initialized and superuser password is not specified.     "
+          "       Please set EDGEDB_PASSWORD or EDGEDB_PASSWORD_HASH       "
+          "       environment variable to a non-empty value.               "
+          "                                                                "
+          "       For example:                                             "
+          "                                                                "
+          "       $ docker run -e EDGEDB_PASSWORD=password edgedb/edgedb   "
+        )
+        edbdocker_die "${msg[@]}"
+      fi
+    fi
+
+    bootstrap_opts+=( --bootstrap-command="$bootstrap_cmd" )
+  fi
+
+  if [ -n "${EDGEDB_POSTGRES_DSN}" ]; then
+    edbdocker_log "Bootstrapping EdgeDB instance on remote Postgres cluster..."
+  else
+    edbdocker_log "Bootstrapping EdgeDB instance on the local volume..."
+  fi
+
+  edbdocker_run_temp_server \
+    _edbdocker_bootstrap_cb \
+    _edbdocker_bootstrap_abort_cb \
+    "${bootstrap_opts[@]}"
+}
+
+
+_edbdocker_bootstrap_cb() {
+  local conn_opts
+  local dir
+
+  dir="/edgedb-bootstrap.d"
+  conn_opts=( "$@" )
+
+  if [ "$EDGEDB_DATABASE" != "edgedb" ]; then
+    echo "CREATE DATABASE ${EDGEDB_DATABASE};" \
+      | edgedb "${conn_opts[@]}" --database="edgedb"
+  fi
+
+  if [ -d "${dir}" ]; then
+    local envopts=()
+    local opt
+
+    for opt in "${conn_opts[@]}"; do
+      case "$opt" in
+        --port=*)
+          envopts+=( "EDGEDB_PORT=${opt#*=}" )
+          ;;
+        --host=*)
+          envopts+=( "EDGEDB_HOST=${opt#*=}" )
+          ;;
+        *)
+          ;;
+      esac
+    done
+
+    env "${envopts[@]}" /bin/run-parts --verbose "$dir" --regex='\.sh$'
+
+    # Feeding scripts one by one, so that errors are easier to debug
+    for filename in $(/bin/run-parts --list "$dir" --regex='\.edgeql$'); do
+      edbdocker_log "Bootstrap script $filename"
+      cat "$filename" | edgedb "${conn_opts[@]}"
+    done
+  fi
+}
+
+
+_edbdocker_bootstrap_abort_cb() {
+  if [ -n "${EDGEDB_DATADIR}" ] && [ -e "${EDGEDB_DATADIR}" ]; then
+    (shopt -u nullglob; rm -rf "${EDGEDB_DATADIR}/"* || :)
+  fi
+}
+
+
+# Runs schema migrations found in /dbschema unless EDGEDB_SKIP_MIGRATIONS
+# is set.  Expects either EDGEDB_DATADIR or EDGEDB_POSTGRES_DSN to be set
+# in the environment.  Migrations are applied by a temporary edgedb-server
+# process that gets started on a random port and is shut down once bootstrap
+# is complete.
+#
+# Usage: `EDGEDB_DATADIR=/foo/bar edbdocker_run_migrations`
+edbdocker_run_migrations() {
+  if [ -d "/dbschema" ] && [ -z "${EDGEDB_SKIP_MIGRATIONS:-}" ]; then
+    local server_opts
+
+    server_opts=()
+    if [ -n "${EDGEDB_POSTGRES_DSN}" ]; then
+      server_opts+=(--postgres-dsn="${EDGEDB_POSTGRES_DSN}")
+    else
+      server_opts+=(--data-dir="${EDGEDB_DATADIR}")
+    fi
+
+    edbdocker_log "Applying schema migrations..."
+    edbdocker_run_temp_server \
+      _edbdocker_migrations_cb \
+      _edbdocker_migrations_abort_cb \
+      "${server_opts[@]}"
+  fi
+}
+
+
+_edbdocker_migrations_cb() {
+  if ! edgedb "${@}" migrate --schema-dir=/dbschema; then
+    edbdocker_log "ERROR: Migrations failed. Stopping server."
+    return 1
+  fi
+}
+
+
+_edbdocker_migrations_abort_cb() {
+  :
+}
+
+
+# Write arguments to stderr separated by newlines.
+# Example: `edbdocker_log "some" "long" "message"`
+# will output:
+#   some
+#   long
+#   message
+#
+edbdocker_log() {
+  printf >&2 "%s\n" "${@}"
+}
+
+
+# Log arguments to stderr using `edbdocker_log` and exit with 1.
+edbdocker_die() {
+  edbdocker_log "${@}"
+  exit 1
+}
+
+
+# Start edgedb-server on a random port, execute the specified callback
+# and shut down the server.
+#
+# Usage: `edbdocker_run_temp_server callback abort_callback --server-arg=val ...`
+edbdocker_run_temp_server() {
+  local edgedb_pid
+  local shell_pid
+  local timeout_pid
+  local timeout
+  local retry_period
+  local runstate_dir
+  local port
+  local ecode
+  local server_opts
+  local conn_opts
+  local callback
+
+  callback="$1"
+  abort_callback="$2"
+  shift 2
+  server_opts=( "${@}" )
+
+  runstate_dir="$(mktemp -d)"
+  server_opts+=(
+    --runstate-dir="$runstate_dir"
+    --port="auto"
+    --bind-address="127.0.0.1"
+  )
+  conn_opts=( --admin --host="$runstate_dir" --wait-until-available="2s" )
+
+  # Start the server
+  edgedb-server "${server_opts[@]}" &
+  edgedb_pid="$!"
+
+  timeout=120
+  retry_period=5
+
+  function _abort() {
+    $abort_callback
+    if [ -e "${runstate_dir}" ]; then
+      rm -r "${runstate_dir}" || :
+    fi
+    edbdocker_die "$1"
+  }
+
+  (
+    local port
+    local sock
+    local i
+    local check
+
+    shopt -s nullglob  # to properly match the Unix socket
+
+    for i in $(seq 1 $(($timeout / $retry_period))); do
+      sleep $retry_period
+      if [ "${runstate_dir}/.s.EDGEDB.admin."* ]; then
+        break
+      fi
+    done
+
+    for sock in "${runstate_dir}/.s.EDGEDB.admin."*; do
+      port="${sock##*.}"
+      break
+    done
+
+    if [ -z "${port}" ]; then
+      _abort "ERROR: Server socket did not appear within ${timeout} seconds."
+    fi
+
+    check_args=(
+      --admin
+      --host="${runstate_dir}"
+      --port="${port}"
+      --database="edgedb"
+      --wait-until-available="2s"
+      query "SELECT 1"
+    )
+
+    if ! edgedb "${check_args[@]}" >/dev/null; then
+      _abort ""
+    fi
+
+    sleep 1
+  ) &
+  timeout_pid="$!"
+
+  set +e
+  wait -n "$edgedb_pid" "$timeout_pid"
+  ecode=$?
+  if [ $ecode -eq 0 ]; then
+    # The first succeeding task would be the server due
+    # to a trailing sleep above.
+    wait "$timeout_pid"
+    ecode=$?
+  fi
+  if [ $ecode -ne 0 ]; then
+    _abort "ERROR: Could not bootstrap EdgeDB server instance."
+  fi
+  set -e
+
+  for sock in "${runstate_dir}/.s.EDGEDB.admin."*; do
+    port="${sock##*.}"
+    break
+  done
+
+  if [ -z "${port}" ]; then
+    _abort "ERROR: EdgeDB server seems to have died before bootstrap could complete."
+  fi
+
+  conn_opts+=( --port="${port}" )
+
+  $callback "${conn_opts[@]}"
+
+  shell_pid=$$
+  trap "_abort" 10
+
+  kill $edgedb_pid
+  (
+    sleep 10;
+    edbdocker_log "ERROR: Could not complete bootstrap: server did not stop within 10 seconds."
+    kill -10 $shell_pid
+  ) &
+  timeout_pid=$!
+  wait $edgedb_pid
+  kill $timeout_pid
+  trap - 10
+
+  rm -r "${runstate_dir}" || :
+}
+
+
+# Allow this script to be sourced without any side-effects other than
+# making the functions available in the sourcing script.
+if [ "${#FUNCNAME[@]}" -ge 1 ] && [ "${FUNCNAME[1]}" = "source" ]; then
+  :
+else
+  edbdocker_main "$@"
 fi
-
-
-exec "$@"

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -15,7 +15,7 @@ teardown() {
         echo "--- CONTAINER: $cont ---"
         docker logs "$cont"
     done
-    if [[ ${#containers[@]} ]]; then
+    if [ ${#containers[@]} -gt 0 ]; then
         docker rm -f "${containers[@]}"
     fi
 }


### PR DESCRIPTION
Reorganize `docker-entrypoint.sh` code into functions for better 
maintainability and implement the following improvements:

- add support for `EDGEDB_PASSWORD_FILE` and other similar variables to
  facilitate a more secure specification of secrets;
- add support for remote PostgreSQL clusters via `EDGEDB_POSTGRES_DSN`
  or `--postgres-dsn`;
- add support for `EDGEDB_PORT` (or `--port`) and `EDGEDB_BIND_ADDRESS`
  (or `--bind-address`) to modify server listening parameters, which
  might be useful for `host` networking mode;
- run bootstrap and migrations with a temporary server on a random port
  to avoid exposing the server to the network in half-initialized state.