### PR TITLE
Fix tests and adjust the TLS notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ $ docker run --name edgedb -e EDGEDB_PASSWORD=secret \
 See the [Customization](#customization) section below for the meaning of
 the `EDGEDB_PASSWORD` variable and other options.
 
-Then authenticate to the EdgeDB instance and store the credentials in
-e.g. a Docker volume:
+Then, to authenticate to the EdgeDB instance and store the credentials in
+a Docker volume, run:
 
 ```shell
-$ docker run --rm --link=edgedb -e EDGEDB_PASSWORD=secret \
+$ docker run -it --rm --link=edgedb -e EDGEDB_PASSWORD=secret \
     -v edgedb-cli-config:/.config/edgedb edgedb/edgedb-cli \
-    -H edgedb authenticate --non-interactive my_instance
+    -H edgedb instance link my_instance
 ```
 
 Now, to open an interactive shell to the database instance run this:

--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -493,18 +493,37 @@ _edbdocker_bootstrap_cb() {
   if [ -z "${EDGEDB_HIDE_GENERATED_CERT}" ]; then
     if [ -n "${EDGEDB_DATADIR}" ] && [ -n "${EDGEDB_GENERATE_SELF_SIGNED_CERT}" ]; then
       msg=(
-        "=============================================================== "
-        "NOTICE: TLS certificate is generated at the following path:     "
-        "            ${EDGEDB_DATADIR}/edbtlscert.pem                    "
+        "================================================================"
+        "                             NOTICE                             "
+        "                             ------                             "
         "                                                                "
-        "        For your convenience, the generated certificate is      "
-        "        echoed below. Please remember to include the BEGIN      "
-        "        and END CERTIFICATE lines, and use this certificate     "
-        "        to establish connections to this EdgeDB instance:       "
-        "=============================================================== "
+        "A TLS certificate has been generated as 'edbtlscert.pem' in the "
+        "server data directory ('${EDGEDB_DATADIR}' in this container).  "
+        "                                                                "
+        "For your convenience, the generated certificate is printed below"
+        "Please remember to include the BEGIN and END CERTIFICATE lines, "
+        "and use this certificate to establish connections to this EdgeDB"
+        "instance.                                                       "
+        "                                                                "
       )
       edbdocker_log "${msg[@]}"
       edbdocker_log "$(cat ${EDGEDB_DATADIR}/edbtlscert.pem)"
+      msg=(
+        "                                                                "
+        "If you have the EdgeDB CLI isntalled on the host system, you can"
+        "also persist the authentication credentials and the certificate "
+        "by running:                                                     "
+        "                                                                "
+        "    edgedb -u ${EDGEDB_USER} --port=<published-port> \          "
+        "        --password instance link --trust-tls-cert my_instance   "
+        "                                                                "
+        "and then connect to it via:                                     "
+        "                                                                "
+        "    edgedb -I my_instance                                       "
+        "                                                                "
+        "================================================================"
+      )
+      edbdocker_log "${msg[@]}"
     fi
   fi
 

--- a/tests/auth.bats
+++ b/tests/auth.bats
@@ -1,4 +1,5 @@
 containers=()
+instances=()
 
 setup() {
     slot=$(
@@ -15,12 +16,19 @@ teardown() {
         echo "--- CONTAINER: $cont ---"
         docker logs "$cont"
     done
-    docker rm -f "${containers[@]}"
+    if [ ${#containers[@]} -gt 0 ]; then
+        docker rm -f "${containers[@]}" || :
+    fi
+    for instance in "${instances[@]}"; do
+        edgedb instance unlink "${instance}" || :
+    done
 }
 
 @test "new user plain password" {
-    container_id="edb_dock_$(uuidgen)"
+    container_id="edb_dock_$(uuidgen | sed s/-//g)"
     containers+=($container_id)
+    instance="testinst_$(uuidgen | sed s/-//g)"
+    instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_USER=test1 \
         --env=EDGEDB_PASSWORD=test2 \
@@ -30,16 +38,18 @@ teardown() {
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
     echo test2 | edgedb --wait-until-available=120s -P$port \
         -u test1 --password-from-stdin \
-        authenticate --non-interactive _localtest
-    output=$(edgedb -I _localtest \
+        instance link --trust-tls-cert --non-interactive "${instance}"
+    output=$(edgedb -I "${instance}" \
         query "SELECT 7+7")
     run echo "$output"
     [[ ${lines[-1]} = "14" ]]
 }
 
 @test "new user hashed password" {
-    container_id="edb_dock_$(uuidgen)"
+    container_id="edb_dock_$(uuidgen | sed s/-//g)"
     containers+=($container_id)
+    instance="testinst_$(uuidgen | sed s/-//g)"
+    instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_USER=test1 \
         --env='EDGEDB_PASSWORD_HASH=SCRAM-SHA-256$4096:rEQ2xuv6ASCA61VMaqU9yg==$uvda3+u+zewd/GvbIofDjk5EEReNJ0KRhLX0001bVRQ=:sdF5jXfPMnM9GNu+JC39fV4Pa5oZEULEm8cdDRZMJDw=' \
@@ -49,16 +59,18 @@ teardown() {
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
     echo test3 | edgedb --wait-until-available=120s -P$port \
         -u test1 --password-from-stdin \
-        authenticate --non-interactive _localtest
-    output=$(edgedb -I _localtest \
+        instance link --trust-tls-cert --non-interactive "${instance}"
+    output=$(edgedb -I "${instance}" \
         query "SELECT 7*3")
     run echo "$output"
     [[ ${lines[-1]} = "21" ]]
 }
 
 @test "create role manually (via env)" {
-    container_id="edb_dock_$(uuidgen)"
+    container_id="edb_dock_$(uuidgen | sed s/-//g)"
     containers+=($container_id)
+    instance="testinst_$(uuidgen | sed s/-//g)"
+    instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_BOOTSTRAP_COMMAND="CREATE SUPERUSER ROLE test1 { SET password := 'test4'; };" \
         --env=EDGEDB_GENERATE_SELF_SIGNED_CERT=1 \
@@ -67,16 +79,18 @@ teardown() {
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
     echo test4 | edgedb --wait-until-available=120s -P$port \
         -u test1 --password-from-stdin \
-        authenticate --non-interactive _localtest
-    output=$(edgedb -I _localtest \
+        instance link --trust-tls-cert --non-interactive "${instance}"
+    output=$(edgedb -I "${instance}" \
         query "SELECT 7*4")
     run echo "$output"
     [[ ${lines[-1]} = "28" ]]
 }
 
 @test "create role manually (via cmdline)" {
-    container_id="edb_dock_$(uuidgen)"
+    container_id="edb_dock_$(uuidgen | sed s/-//g)"
     containers+=($container_id)
+    instance="testinst_$(uuidgen | sed s/-//g)"
+    instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         edgedb/edgedb:latest \
         --generate-self-signed-cert \
@@ -85,16 +99,18 @@ teardown() {
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
     echo test5 | edgedb --wait-until-available=120s -P$port \
         -u test1 --password-from-stdin \
-        authenticate --non-interactive _localtest
-    output=$(edgedb -I _localtest \
+        instance link --trust-tls-cert --non-interactive "${instance}"
+    output=$(edgedb -I "${instance}" \
         query "SELECT 7*4")
     run echo "$output"
     [[ ${lines[-1]} = "28" ]]
 }
 
 @test "edgedb: plain password" {
-    container_id="edb_dock_$(uuidgen)"
+    container_id="edb_dock_$(uuidgen | sed s/-//g)"
     containers+=($container_id)
+    instance="testinst_$(uuidgen | sed s/-//g)"
+    instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_PASSWORD=test2 \
         --env=EDGEDB_GENERATE_SELF_SIGNED_CERT=1 \
@@ -103,16 +119,18 @@ teardown() {
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
     echo test2 | edgedb --wait-until-available=120s -P$port \
         --password-from-stdin \
-        authenticate --non-interactive _localtest
-    output=$(edgedb -I _localtest \
+        instance link --trust-tls-cert --non-interactive "${instance}"
+    output=$(edgedb -I "${instance}" \
         query "SELECT 7+7")
     run echo "$output"
     [[ ${lines[-1]} = "14" ]]
 }
 
 @test "edgedb: hashed password" {
-    container_id="edb_dock_$(uuidgen)"
+    container_id="edb_dock_$(uuidgen | sed s/-//g)"
     containers+=($container_id)
+    instance="testinst_$(uuidgen | sed s/-//g)"
+    instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         --env='EDGEDB_PASSWORD_HASH=SCRAM-SHA-256$4096:rEQ2xuv6ASCA61VMaqU9yg==$uvda3+u+zewd/GvbIofDjk5EEReNJ0KRhLX0001bVRQ=:sdF5jXfPMnM9GNu+JC39fV4Pa5oZEULEm8cdDRZMJDw=' \
         --env=EDGEDB_GENERATE_SELF_SIGNED_CERT=1 \
@@ -121,16 +139,18 @@ teardown() {
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
     echo test3 | edgedb --wait-until-available=120s -P$port \
         --password-from-stdin \
-        authenticate --non-interactive _localtest
-    output=$(edgedb -I _localtest \
+        instance link --trust-tls-cert --non-interactive "${instance}"
+    output=$(edgedb -I "${instance}" \
         query "SELECT 7*3")
     run echo "$output"
     [[ ${lines[-1]} = "21" ]]
 }
 
 @test "named database" {
-    container_id="edb_dock_$(uuidgen)"
+    container_id="edb_dock_$(uuidgen | sed s/-//g)"
     containers+=($container_id)
+    instance="testinst_$(uuidgen | sed s/-//g)"
+    instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_DATABASE=hello \
         --env=EDGEDB_USER=test1 \
@@ -141,8 +161,8 @@ teardown() {
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
     echo test5 | edgedb --wait-until-available=120s -P$port \
         -d hello -u test1 --password-from-stdin \
-        authenticate --non-interactive _localtest
-    output=$(edgedb -I _localtest \
+        instance link --trust-tls-cert --non-interactive "${instance}"
+    output=$(edgedb -I "${instance}" \
         query "SELECT 7+7")
     run echo "$output"
     [[ ${lines[-1]} = "14" ]]

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -1,4 +1,5 @@
 containers=()
+instances=()
 
 setup() {
     slot=$(
@@ -16,13 +17,18 @@ teardown() {
         docker logs "$cont"
     done
     if [ ${#containers[@]} -gt 0 ]; then
-        docker rm -f "${containers[@]}"
+        docker rm -f "${containers[@]}" || :
     fi
+    for instance in "${instances[@]}"; do
+        edgedb instance unlink "${instance}" || :
+    done
 }
 
 @test "full bootstrap" {
-    container_id="edb_dock_$(uuidgen)"
+    container_id="edb_dock_$(uuidgen | sed s/-//g)"
     containers+=($container_id)
+    instance="testinst_$(uuidgen | sed s/-//g)"
+    instances+=($instance)
     # The user declared here is ignored
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_GENERATE_SELF_SIGNED_CERT=1 \
@@ -31,8 +37,8 @@ teardown() {
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
     echo password2 | edgedb --wait-until-available=120s -P$port \
         -u user1 --password-from-stdin \
-        authenticate --non-interactive _localtest
-    output=$(edgedb -I _localtest \
+        instance link --trust-tls-cert --non-interactive "${instance}"
+    output=$(edgedb -I "${instance}" \
         --tab-separated query "SELECT Bootstrap.name ORDER BY Bootstrap.name")
     echo "$output"
     run echo "$output"


### PR DESCRIPTION
`edgedb authenticate` is no more, use `edgedb instance link`.

Depends on a CLI fix in edgedb/edgedb-cli#446