### PR TITLE
Fix `EDGEDB_SERVER_DATADIR` default value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ usually doesn't need to be changed unless you run in `host` networking mode.
 #### `EDGEDB_SERVER_DATADIR`, `--data-dir`
 
 Specifies a path within the container in which the database files are located.
-Defaults to `/var/run/edgedb/data`.  The container needs to be able to
+Defaults to `/var/lib/edgedb/data`.  The container needs to be able to
 change the ownership of the mounted directory to `edgedb`.  Cannot be specified
 at the same time with `EDGEDB_SERVER_POSTGRES_DSN`.
 


### PR DESCRIPTION
Update `EDGEDB_SERVER_DATADIR` default value in README in accordance to:
https://github.com/edgedb/edgedb-docker/blob/37e6ed933e317beaaad8935e01cabe8249698072/docker-entrypoint-funcs.sh#L302