### PR TITLE
Add support for `EDGEDB_TLS_CERT_MODE` and do a bunch of cleanups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ export DEBIAN_FRONTEND=noninteractive; \
             locales \
             procps \
             gosu \
+            jq \
     && s=0 && break || s=$?; done; exit $s \
 ) \
 && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8\

--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ EdgeDB servers.
 The simplest way to run the image (without data persistence) is this:
 
 ```shell
-$ docker run --name edgedb -e EDGEDB_SERVER_PASSWORD=secret \
-    -e EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 -d edgedb/edgedb
+$ docker run --name edgedb -d \
+    -e EDGEDB_SERVER_PASSWORD=secret \
+    -e EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
+    edgedb/edgedb
 ```
 
 See the [Customization](#customization) section below for the meaning of
-the `EDGEDB_SERVER_PASSWORD` variable and other options.
+the `EDGEDB_SERVER_SECURITY` variable and other options.
 
 Then, to authenticate to the EdgeDB instance and store the credentials in
 a Docker volume, run:
@@ -66,7 +68,7 @@ you must mount a persistent volume at the path specified by
 ```shell
 $ docker run \
     --name edgedb -e EDGEDB_SERVER_PASSWORD=secret \
-    -e EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+    -e EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
     -v /my/data/directory:/var/lib/edgedb/data \
     -d edgedb/edgedb
 ```
@@ -77,7 +79,7 @@ Note that on Windows you must use a Docker volume instead:
 $ docker volume create --name=edgedb-data
 $ docker run \
     --name edgedb -e EDGEDB_SERVER_PASSWORD=secret \
-    -e EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+    -e EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
     -v edgedb-data:/var/lib/edgedb/data \
     -d edgedb/edgedb
 ```

--- a/tests/auth.bats
+++ b/tests/auth.bats
@@ -3,7 +3,7 @@ instances=()
 
 setup() {
     slot=$(
-        curl https://packages.edgedb.com/apt/.jsonindexes/stretch.nightly.json \
+        curl https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json \
         | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
     docker build -t edgedb/edgedb:latest \
         --build-arg "version=$slot" --build-arg "subdist=.nightly" \
@@ -32,7 +32,7 @@ teardown() {
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_SERVER_USER=test1 \
         --env=EDGEDB_SERVER_PASSWORD=test2 \
-        --env=EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
         edgedb/edgedb:latest
     port=$(docker inspect "$container_id" \
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
@@ -53,7 +53,7 @@ teardown() {
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_SERVER_USER=test1 \
         --env=EDGEDB_SERVER_PASSWORD=test2 \
-        --env=EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
         edgedb/edgedb:latest
     port=$(docker inspect "$container_id" \
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
@@ -74,7 +74,7 @@ teardown() {
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_SERVER_USER=test1 \
         --env='EDGEDB_SERVER_PASSWORD_HASH=SCRAM-SHA-256$4096:rEQ2xuv6ASCA61VMaqU9yg==$uvda3+u+zewd/GvbIofDjk5EEReNJ0KRhLX0001bVRQ=:sdF5jXfPMnM9GNu+JC39fV4Pa5oZEULEm8cdDRZMJDw=' \
-        --env=EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
         edgedb/edgedb:latest
     port=$(docker inspect "$container_id" \
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
@@ -94,7 +94,7 @@ teardown() {
     instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_SERVER_BOOTSTRAP_COMMAND="CREATE SUPERUSER ROLE test1 { SET password := 'test4'; };" \
-        --env=EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
         edgedb/edgedb:latest
     port=$(docker inspect "$container_id" \
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
@@ -134,7 +134,7 @@ teardown() {
     instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_SERVER_PASSWORD=test2 \
-        --env=EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
         edgedb/edgedb:latest
     port=$(docker inspect "$container_id" \
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
@@ -154,7 +154,7 @@ teardown() {
     instances+=($instance)
     docker run -d --name=$container_id --publish=5656 \
         --env='EDGEDB_SERVER_PASSWORD_HASH=SCRAM-SHA-256$4096:rEQ2xuv6ASCA61VMaqU9yg==$uvda3+u+zewd/GvbIofDjk5EEReNJ0KRhLX0001bVRQ=:sdF5jXfPMnM9GNu+JC39fV4Pa5oZEULEm8cdDRZMJDw=' \
-        --env=EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
         edgedb/edgedb:latest
     port=$(docker inspect "$container_id" \
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
@@ -176,7 +176,7 @@ teardown() {
         --env=EDGEDB_SERVER_DATABASE=hello \
         --env=EDGEDB_SERVER_USER=test1 \
         --env=EDGEDB_SERVER_PASSWORD=test5 \
-        --env=EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
         edgedb/edgedb:latest
     port=$(docker inspect "$container_id" \
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -3,7 +3,7 @@ instances=()
 
 setup() {
     slot=$(
-        curl https://packages.edgedb.com/apt/.jsonindexes/stretch.nightly.json \
+        curl https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json \
         | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
     docker build -t edgedb/edgedb:latest \
         --build-arg "version=$slot" --build-arg "subdist=.nightly" \
@@ -31,7 +31,7 @@ teardown() {
     instances+=($instance)
     # The user declared here is ignored
     docker run -d --name=$container_id --publish=5656 \
-        --env=EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
         edgedb-test:bootstrap
     port=$(docker inspect "$container_id" \
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')

--- a/tests/compose.bats
+++ b/tests/compose.bats
@@ -1,6 +1,6 @@
 setup() {
     slot=$(
-        curl https://packages.edgedb.com/apt/.jsonindexes/stretch.nightly.json \
+        curl https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json \
         | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
     docker build -t edgedb/edgedb:latest \
         --build-arg "version=$slot" --build-arg "subdist=.nightly" \

--- a/tests/compose_dev_mode.bats
+++ b/tests/compose_dev_mode.bats
@@ -1,6 +1,6 @@
 setup() {
     slot=$(
-        curl https://packages.edgedb.com/apt/.jsonindexes/stretch.nightly.json \
+        curl https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json \
         | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
     docker build -t edgedb/edgedb:latest \
         --build-arg "version=$slot" --build-arg "subdist=.nightly" \

--- a/tests/other.bats
+++ b/tests/other.bats
@@ -1,6 +1,6 @@
 setup() {
     slot=$(
-        curl https://packages.edgedb.com/apt/.jsonindexes/stretch.nightly.json \
+        curl https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json \
         | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
     docker build -t edgedb/edgedb:latest \
         --build-arg "version=$slot" --build-arg "subdist=.nightly" \

--- a/tests/schema.bats
+++ b/tests/schema.bats
@@ -3,7 +3,7 @@ instances=()
 
 setup() {
     slot=$(
-        curl https://packages.edgedb.com/apt/.jsonindexes/stretch.nightly.json \
+        curl https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json \
         | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
     docker build -t edgedb/edgedb:latest \
         --build-arg "version=$slot" --build-arg "subdist=.nightly" \
@@ -33,7 +33,7 @@ teardown() {
     docker run -d --name=$container_id --publish=5656 \
         --env=EDGEDB_SERVER_USER=user1 \
         --env=EDGEDB_SERVER_PASSWORD=password2 \
-        --env=EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
         edgedb-test:schema
     port=$(docker inspect "$container_id" \
         | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')


### PR DESCRIPTION
The entrypoint now supports `EDGEDB_TLS_CERT_MODE` added in
edgedb/edgedb#3213.

Alongside this a set of cleanups:

* use `--emit-server-status` to wait for server and extract the
  port and TLS cert location like we do everywhere else;

* significantly simplify temp server waiting and error handling
  logic;

* stop exporting variables into the environment and enable
  bash `nounset`.