### PR TITLE
Add a script to export secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,6 @@ EXPOSE 5656
 
 VOLUME /var/lib/edgedb/data
 
-COPY docker-entrypoint-funcs.sh docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint-funcs.sh docker-entrypoint.sh edgedb-show-secrets.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["edgedb-server"]

--- a/edgedb-show-secrets.sh
+++ b/edgedb-show-secrets.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+source "/usr/local/bin/docker-entrypoint-funcs.sh"
+
+
+edb_gs_log() {
+  printf >&2 "%s\n" "${@}"
+}
+
+edb_gs_die() {
+  edb_gs_log "${@}"
+  exit 1
+}
+
+edb_gs_usage() {
+  edb_gs_log "Usage: $0 --all | --specifically=<SECRET_NAME> | <SECRET_NAME> [...]"
+  exit "${1:-1}"
+}
+
+edb_gs_parse_args() {
+  _EDB_GS_ONLY=
+  _EDB_GS_ALL=
+  _EDB_GS_SECRETS=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        edb_gs_usage 0
+        ;;
+      --all)
+        if [ -n "${_EDB_GS_ONLY}" ] || [ "${#_EDB_GS_SECRETS[@]}" -gt 0 ]; then
+          edb_gs_log "invalid argument combination"
+          edb_gs_usage
+        fi
+        _EDB_GS_ALL="true"
+        shift
+        ;;
+      --specifically=*)
+        if [ -n "${_EDB_GS_ONLY}" ] || [ -n "${_EDB_GS_ALL}" ]; then
+          edb_gs_log "invalid argument combination"
+          edb_gs_usage
+        fi
+        _EDB_GS_ONLY="${1#*=}"
+        shift
+        ;;
+      -*)
+        edb_gs_log "unexpected option: $1"
+        edb_gs_usage
+        ;;
+      *)
+        if [ -n "${_EDB_GS_ONLY}" ] || [ -n "${_EDB_GS_ALL}" ]; then
+          edb_gs_log "invalid argument combination"
+          edb_gs_usage
+        fi
+        _EDB_GS_SECRETS+=( "$1" )
+        shift
+        ;;
+    esac
+  done
+
+  if [ -z "${_EDB_GS_ONLY}" ] && [ -z "${_EDB_GS_ALL}" ] && [ "${#_EDB_GS_SECRETS[@]}" -eq 0 ]; then
+    edb_gs_usage
+  fi
+}
+
+edb_gs_show_secrets() (
+  local k
+  local v
+  local file
+  local lines
+  local -A map
+
+  while IFS="=" read -r k v; do
+    map["$k"]=$v
+  done < "/etc/edgedb.secrets"
+
+  if [ -n "${_EDB_GS_ONLY}" ]; then
+    file=${map["$_EDB_GS_ONLY"]:-}
+    if [ -z "$file" ]; then
+      edb_gs_die "ERROR: '${_EDB_GS_ONLY}' is not a known secret"
+    fi
+    cat "$file"
+  elif [ -n "${_EDB_GS_ALL}" ]; then
+    for k in "${!map[@]}"; do
+      file=${map["$k"]}
+      edb_gs_show_secret "$k" "$file"
+    done
+  else
+    for k in "${_EDB_GS_SECRETS[@]}"; do
+      file=${map["$k"]:-}
+      if [ -z "$file" ]; then
+        edb_gs_die "ERROR: '${k}' is not a known secret"
+      fi
+    done
+    for k in "${_EDB_GS_SECRETS[@]}"; do
+      file=${map["$k"]}
+      edb_gs_show_secret "$k" "$file"
+    done
+  fi
+)
+
+edb_gs_show_secret() {
+  local name
+  local file
+  name="$1"
+  file="$2"
+
+  v=$(cat "$file")
+  lines=$(wc -l "$file" | cut -f1 -d' ')
+  if [ "$lines" -gt 1 ]; then
+    printf '%s="""\n%s\n"""\n' "$name" "$v"
+  else
+    printf '%s="%v"\n' "$name" "$v"
+  fi
+}
+
+
+edbdocker_setup_shell
+edb_gs_parse_args "$@"
+edb_gs_show_secrets

--- a/tests/show_secrets.bats
+++ b/tests/show_secrets.bats
@@ -35,9 +35,9 @@ teardown() {
         | edgedb --wait-until-available=120s -P$port \
             --password-from-stdin \
             instance link --trust-tls-cert --non-interactive "${instance}"
-    run docker exec "$container_id" edgedb-show-secrets.sh --all
+    run docker exec "$container_id" edgedb-show-secrets.sh --format=toml --all
     [[ ${lines[0]} = EDGEDB_SERVER_* ]]
-    run docker exec "$container_id" edgedb-show-secrets.sh --specifically=EDGEDB_SERVER_TLS_CERT
+    run docker exec "$container_id" edgedb-show-secrets.sh --format=raw EDGEDB_SERVER_TLS_CERT
     [[ ${lines[0]} = "-----BEGIN CERTIFICATE-----" ]]
-    run docker exec "$container_id" edgedb-show-secrets.sh EDGEDB_SERVER_TLS_CERT EDGEDB_SERVER_TLS_KEY
+    run docker exec "$container_id" edgedb-show-secrets.sh --format=shell EDGEDB_SERVER_TLS_CERT EDGEDB_SERVER_TLS_KEY
 }

--- a/tests/show_secrets.bats
+++ b/tests/show_secrets.bats
@@ -1,0 +1,43 @@
+containers=()
+instances=()
+
+setup() {
+    slot=$(
+        curl https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json \
+        | jq -r '[.packages[] | select(.basename == "edgedb-server")] | sort_by(.slot) | reverse | .[0].slot')
+    docker build -t edgedb/edgedb:latest \
+        --build-arg "version=$slot" --build-arg "subdist=.nightly" \
+        .
+}
+
+teardown() {
+    for cont in "${containers[@]}"; do
+        echo "--- CONTAINER: $cont ---"
+        docker logs "$cont"
+    done
+    if [ ${#containers[@]} -gt 0 ]; then
+        docker rm -f "${containers[@]}" || :
+    fi
+}
+
+@test "show secrets" {
+    container_id="edb_dock_$(uuidgen | sed s/-//g)"
+    containers+=($container_id)
+    instance="testinst_$(uuidgen | sed s/-//g)"
+    instances+=($instance)
+    docker run -d --name=$container_id --publish=5656 \
+        --env=EDGEDB_PASSWORD=password2 \
+        --env=EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
+        edgedb/edgedb:latest
+    port=$(docker inspect "$container_id" \
+        | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
+    echo password2 \
+        | edgedb --wait-until-available=120s -P$port \
+            --password-from-stdin \
+            instance link --trust-tls-cert --non-interactive "${instance}"
+    run docker exec "$container_id" edgedb-show-secrets.sh --all
+    [[ ${lines[0]} = EDGEDB_SERVER_* ]]
+    run docker exec "$container_id" edgedb-show-secrets.sh --specifically=EDGEDB_SERVER_TLS_CERT
+    [[ ${lines[0]} = "-----BEGIN CERTIFICATE-----" ]]
+    run docker exec "$container_id" edgedb-show-secrets.sh EDGEDB_SERVER_TLS_CERT EDGEDB_SERVER_TLS_KEY
+}


### PR DESCRIPTION
This adds `edgedb-show-secrets.sh` to the container as a way to easily
obtain the raw value of a specific known secret, or a set of specified
secrets, or all of known secrets, in TOML format:

```
   docker exec <container> edgedb-show-secrets.sh \
       --format=toml EDGEDB_SERVER_TLS_CERT EDGEDB_SERVER_TLS_KEY
```

or

```
   docker exec <container> edgedb-show-secrets.sh \
       --format=shell --all
```

This helper is especially useful when one wants to preserve the
generated TLS certificate and key as a secret on a hosting platform.