### PR TITLE
EDGEDB_SERVER_TLS_CERT_MODE generate_self_signed -> 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The simplest way to run the image (without data persistence) is this:
 ```shell
 $ docker run --name edgedb -d \
     -e EDGEDB_SERVER_PASSWORD=secret \
-    -e EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
+    -e EDGEDB_SERVER_TLS_CERT_MODE=1 \
     edgedb/edgedb
 ```
 
@@ -68,7 +68,7 @@ you must mount a persistent volume at the path specified by
 ```shell
 $ docker run \
     --name edgedb -e EDGEDB_SERVER_PASSWORD=secret \
-    -e EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
+    -e EDGEDB_SERVER_TLS_CERT_MODE=1 \
     -v /my/data/directory:/var/lib/edgedb/data \
     -d edgedb/edgedb
 ```
@@ -79,7 +79,7 @@ Note that on Windows you must use a Docker volume instead:
 $ docker volume create --name=edgedb-data
 $ docker run \
     --name edgedb -e EDGEDB_SERVER_PASSWORD=secret \
-    -e EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed \
+    -e EDGEDB_SERVER_TLS_CERT_MODE=1 \
     -v edgedb-data:/var/lib/edgedb/data \
     -d edgedb/edgedb
 ```


### PR DESCRIPTION
`generate_self_signed` was ignored for me while `1`, as per the example embedded in the error, `docker run -e EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT=1 edgedb/edgedb`, works. 