### PR TITLE
Fix running as non-root

### DIFF
--- a/edgedb-show-secrets.sh
+++ b/edgedb-show-secrets.sh
@@ -82,7 +82,7 @@ edb_gs_show_secrets() (
 
   while IFS="=" read -r k v; do
     map["$k"]=$v
-  done < "/etc/edgedb.secrets"
+  done < "/tmp/edgedb/secrets"
 
   if [ -n "${_EDB_GS_ALL}" ]; then
     for k in "${!map[@]}"; do

--- a/tests/other.bats
+++ b/tests/other.bats
@@ -8,3 +8,14 @@ setup() {
   run docker run --rm edgedb/edgedb:latest sh -c 'echo "CMD $((7*3))"'
   [[ ${lines[-1]} = "CMD 21" ]]
 }
+
+@test "run as non-root" {
+  local container_id
+  local instance
+
+  create_instance container_id instance '{}' -u nobody \
+    --env=EDGEDB_SERVER_DATADIR=/tmp/data
+
+  run edgedb -I "${instance}" query "SELECT 7+7"
+  [[ ${lines[-1]} = "14" ]]
+}

--- a/tests/testbase.bash
+++ b/tests/testbase.bash
@@ -135,6 +135,9 @@ create_instance() {
   docker run -d --name="${_container}" "${docker_args[@]}" \
     "$image" "${image_args[@]}"
 
+  echo docker run -d --name="${_container}" "${docker_args[@]}" \
+    "$image" "${image_args[@]}"
+
   port=$(docker inspect "${_container}" \
     | jq -r '.[0].NetworkSettings.Ports["5656/tcp"][0].HostPort')
 


### PR DESCRIPTION
Don't attempt to write outside of `/tmp` when the container isn't
running as root.