### PR TITLE
Add support for "late" bootstrap hooks

### DIFF
--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -22,4 +22,6 @@ teardown() {
   [[ ${lines[0]} = "01-shell script" ]]
   [[ ${lines[1]} = "02-edgeql file" ]]
   [[ ${lines[2]} = "03-edgeql file" ]]
+  [[ ${lines[3]} = "04-shell script late" ]]
+  [[ ${lines[4]} = "05-edgeql file late" ]]
 }

--- a/tests/bootstrap/Dockerfile
+++ b/tests/bootstrap/Dockerfile
@@ -1,3 +1,5 @@
 FROM edgedb/edgedb:latest
 COPY /edgedb-bootstrap.edgeql /
 COPY /edgedb-bootstrap.d/* /edgedb-bootstrap.d/
+COPY /edgedb-bootstrap-late.d/* /edgedb-bootstrap-late.d/
+COPY /dbschema /dbschema

--- a/tests/bootstrap/dbschema/migrations/00001.edgeql
+++ b/tests/bootstrap/dbschema/migrations/00001.edgeql
@@ -1,0 +1,7 @@
+CREATE MIGRATION m1oxl4rvtybznqogrm6f2qj5eecevxohrhaj4xiimotv2s6zt2efcq
+    ONTO initial
+{
+  CREATE TYPE Bootstrap {
+    CREATE PROPERTY name -> str;
+  };
+};

--- a/tests/bootstrap/dbschema/migrations/00002.edgeql
+++ b/tests/bootstrap/dbschema/migrations/00002.edgeql
@@ -1,0 +1,5 @@
+CREATE MIGRATION m1xg7amx4pq3urciy3gsodwoe2snqx3owetyq7qznubasy3si3ljgq
+    ONTO m1oxl4rvtybznqogrm6f2qj5eecevxohrhaj4xiimotv2s6zt2efcq
+{
+  CREATE TYPE default::Bootstrap2 EXTENDING default::Bootstrap;
+};

--- a/tests/bootstrap/edgedb-bootstrap-late.d/04.sh
+++ b/tests/bootstrap/edgedb-bootstrap-late.d/04.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+edgedb --admin query "INSERT Bootstrap2 { name := '04-shell script late' }"

--- a/tests/bootstrap/edgedb-bootstrap-late.d/05.edgeql
+++ b/tests/bootstrap/edgedb-bootstrap-late.d/05.edgeql
@@ -1,0 +1,1 @@
+INSERT Bootstrap2 { name := '05-edgeql file late' }


### PR DESCRIPTION
Currently, `/edgedb-bootstrap.d` is executed _before_ migrations are
applied, which could be inconvenient if custom bootstrap relies on the
schema.  This lets putting bootstrap parts in `/edgedb-bootstrap-late.d`
to be executed _after_ the migrations have been applied.