### PR TITLE
Stop using Unix sockets for bootstrap

### DIFF
--- a/tests/bootstrap/edgedb-bootstrap-late.d/04.sh
+++ b/tests/bootstrap/edgedb-bootstrap-late.d/04.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-edgedb --admin query "INSERT Bootstrap2 { name := '04-shell script late' }"
+edgedb query "INSERT Bootstrap2 { name := '04-shell script late' }"

--- a/tests/bootstrap/edgedb-bootstrap.d/01.sh
+++ b/tests/bootstrap/edgedb-bootstrap.d/01.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-edgedb --admin query "INSERT Bootstrap { name := '01-shell script' }"
+edgedb query "INSERT Bootstrap { name := '01-shell script' }"


### PR DESCRIPTION
With recent CLI changes using `--admin` no longer works (because
`EDGEDB_HOST` no longer allows Unix sockets).  Since bootstrap server
only listens on loopback we can use TCP with Trust default authentication
method.  In case an explicit auth is configured, use `EDGEDB_USER` and
`EDGEDB_PASSWORD` as specified in the environment.