### PR TITLE
fix #72 tenant-id isn't supported

### DIFF
--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -341,6 +341,10 @@ edbdocker_run_server() {
     server_args+=(--compiler-pool-size="${EDGEDB_SERVER_COMPILER_POOL_SIZE}")
   fi
 
+  if [ -n "${EDGEDB_SERVER_TENANT_ID}" ]; then
+    server_args+=(--tenant-id="${EDGEDB_SERVER_TENANT_ID}")
+  fi
+
   server_args+=( "${_EDGEDB_DOCKER_CMDLINE_ARGS[@]}" )
 
   status_file="$(edbdocker_mktemp_for_server)"
@@ -1142,6 +1146,10 @@ edbdocker_run_temp_server() {
     fi
   else
     server_opts+=(--data-dir="${EDGEDB_SERVER_DATADIR}")
+  fi
+
+  if [ -n "${EDGEDB_SERVER_TENANT_ID}" ]; then
+    server_opts+=(--tenant-id="${EDGEDB_SERVER_TENANT_ID}")
   fi
 
   if [ -n "${EDGEDB_SERVER_TLS_CERT_MODE}" ]; then

--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -87,6 +87,14 @@ edbdocker_parse_args() {
         EDGEDB_SERVER_BACKEND_DSN="${1#*=}"
         shift
         ;;
+      --tenant-id)
+        _edbdocker_parse_arg "EDGEDB_SERVER_TENANT_ID" "$1" "$2"
+        shift 2
+        ;;
+      --tenant-id=*)
+        EDGEDB_SERVER_TENANT_ID="${1#*=}"
+        shift
+        ;;
       -P|--port)
         _edbdocker_parse_arg "EDGEDB_SERVER_PORT" "$1" "$2"
         shift 2

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -25,3 +25,23 @@ teardown() {
   [[ ${lines[3]} = "04-shell script late" ]]
   [[ ${lines[4]} = "05-edgeql file late" ]]
 }
+
+@test "full bootstrap tenant id" {
+  local container_id
+  local instance
+  local tenant_id
+
+  create_instance container_id instance '{"image":"edgedb-test:bootstrap"}' \
+    -- \
+    --tenant-id=tenant_id
+
+  output=$(edgedb -I "${instance}" query --output-format=tab-separated \
+    "SELECT Bootstrap.name ORDER BY Bootstrap.name")
+  echo "$output"
+  run echo "$output"
+  [[ ${lines[0]} = "01-shell script" ]]
+  [[ ${lines[1]} = "02-edgeql file" ]]
+  [[ ${lines[2]} = "03-edgeql file" ]]
+  [[ ${lines[3]} = "04-shell script late" ]]
+  [[ ${lines[4]} = "05-edgeql file late" ]]
+}


### PR DESCRIPTION
we need to pass the tenant_id as environemnt variable to the temp server. Otherwise the bootstrap and check initalize steps will start without the tenant_id. This leads to a bootstrap of a wrong tenant and afterwards a check failure, because the instance seems to be not initialized.