### PR TITLE
Fix `EDGEDB_SERVER_BOOTSTRAP_ONLY` mode on 3.x

### DIFF
--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -33,7 +33,7 @@ teardown() {
 
   create_instance container_id instance '{"image":"edgedb-test:bootstrap"}' \
     -- \
-    --tenant-id=tenant_id
+    --tenant-id=tenantid
 
   output=$(edgedb -I "${instance}" query --output-format=tab-separated \
     "SELECT Bootstrap.name ORDER BY Bootstrap.name")

--- a/tests/bootstrap/Dockerfile
+++ b/tests/bootstrap/Dockerfile
@@ -2,4 +2,3 @@ FROM edgedb/edgedb:latest
 COPY /edgedb-bootstrap.edgeql /
 COPY /edgedb-bootstrap.d/* /edgedb-bootstrap.d/
 COPY /edgedb-bootstrap-late.d/* /edgedb-bootstrap-late.d/
-COPY /dbschema /dbschema

--- a/tests/bootstrap/dbschema/migrations/00001.edgeql
+++ b/tests/bootstrap/dbschema/migrations/00001.edgeql
@@ -1,7 +1,0 @@
-CREATE MIGRATION m1oxl4rvtybznqogrm6f2qj5eecevxohrhaj4xiimotv2s6zt2efcq
-    ONTO initial
-{
-  CREATE TYPE Bootstrap {
-    CREATE PROPERTY name -> str;
-  };
-};

--- a/tests/bootstrap/dbschema/migrations/00002.edgeql
+++ b/tests/bootstrap/dbschema/migrations/00002.edgeql
@@ -1,5 +1,0 @@
-CREATE MIGRATION m1xg7amx4pq3urciy3gsodwoe2snqx3owetyq7qznubasy3si3ljgq
-    ONTO m1oxl4rvtybznqogrm6f2qj5eecevxohrhaj4xiimotv2s6zt2efcq
-{
-  CREATE TYPE default::Bootstrap2 EXTENDING default::Bootstrap;
-};

--- a/tests/bootstrap/edgedb-bootstrap.edgeql
+++ b/tests/bootstrap/edgedb-bootstrap.edgeql
@@ -2,3 +2,4 @@ CREATE SUPERUSER ROLE user1 { SET password := 'password2'; };
 CREATE TYPE Bootstrap {
     CREATE PROPERTY name -> str;
 };
+CREATE TYPE Bootstrap2 EXTENDING Bootstrap;

--- a/tests/compose.bats
+++ b/tests/compose.bats
@@ -6,12 +6,13 @@ setup() {
 }
 
 teardown() {
-    docker-compose logs
-    docker-compose rm --stop --force -v
+    docker compose logs
+    docker compose down --remove-orphans
+    docker compose rm --force --volumes
 }
 
 @test "composed app works" {
-    docker-compose up --detach --build
+    docker compose up --detach --build
     for i in {0..120}; do
         output=$(curl -s http://localhost:34089/increment/some) || output="500"
         if ! [[ $output =~ ^500 ]]; then

--- a/tests/compose_dev_mode.bats
+++ b/tests/compose_dev_mode.bats
@@ -6,12 +6,13 @@ setup() {
 }
 
 teardown() {
-    docker-compose -f docker-compose-dev.yml logs
-    docker-compose -f docker-compose-dev.yml rm --stop --force -v
+    docker compose -f docker-compose-dev.yml logs
+    docker compose -f docker-compose-dev.yml down --remove-orphans
+    docker compose -f docker-compose-dev.yml rm --force --volumes
 }
 
 @test "composed app works with insecure_dev_mode" {
-    docker-compose -f docker-compose-dev.yml up --detach --build
+    docker compose -f docker-compose-dev.yml up --detach --build
     for i in {0..120}; do
         output=$(curl -s http://localhost:34089/increment/some) || output="500"
         if ! [[ $output =~ ^500 ]]; then

--- a/tests/testbase.bash
+++ b/tests/testbase.bash
@@ -22,6 +22,7 @@ latest_server_ver() {
      .packages[]
      | select(.basename == \"edgedb-server\")
      | select(.slot | contains(\"-rc\") | not)
+     | select(.architecture == \"$(arch)\")
      | .version_key"
 
   ver_key=$(echo "$index" \
@@ -193,6 +194,6 @@ common_teardown() {
     docker rm -f "${containers[@]}" || :
   fi
   for instance in "${instances[@]}"; do
-    edgedb instance unlink "${instance}" || :
+    edgedb instance unlink -I "${instance}" || :
   done
 }


### PR DESCRIPTION
3.x added support for the `EDGEDB_SERVER_BOOTSTRAP_ONLY` environment
variable, which broken the analogous flow in the Docker image
entrypoint.
