### PR TITLE
Add EDGEDB_SERVER_DEFAULT_BRANCH

### DIFF
--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -560,7 +560,7 @@ edbdocker_setup_env() {
   edbdocker_lookup_env_var "EDGEDB_SERVER_COMPILER_POOL_MODE"
   edbdocker_lookup_env_var "EDGEDB_SERVER_COMPILER_POOL_SIZE"
 
-  if [ $(echo ${VERSION} | awk -F '-' '{print $1}') -ge 5 ]; then
+  if [ "$(echo "${VERSION}" | awk -F '-' '{print $1}')" -ge 5 ]; then
     if [ -n "${EDGEDB_SERVER_DATABASE}" ]; then
       if [ -n "${EDGEDB_SERVER_DEFAULT_BRANCH}" ]; then
         edbdocker_die "ERROR: EDGEDB_SERVER_DATABASE and EDGEDB_SERVER_DEFAULT_BRANCH are mutually exclusive, but both are set"
@@ -1008,7 +1008,7 @@ _edbdocker_bootstrap_cb() {
 
   _edbdocker_print_last_generated_cert_if_needed "$status"
 
-  if [ $(echo ${VERSION} | awk -F '-' '{print $1}') -lt 5 ]; then
+  if [ "$(echo "${VERSION}" | awk -F '-' '{print $1}')" -lt 5 ]; then
     if [ "${EDGEDB_SERVER_DATABASE}" != "edgedb" ]; then
       echo "CREATE DATABASE \`${EDGEDB_SERVER_DATABASE}\`;" \
         | edbdocker_cli "${conn_opts[@]}" -- --database="edgedb"
@@ -1261,7 +1261,7 @@ edbdocker_run_temp_server() {
     server_opts+=(--tls-key-file="${EDGEDB_SERVER_TLS_KEY_FILE}")
   fi
 
-  if [ $(echo ${VERSION} | awk -F '-' '{print $1}') -ge 5 ]; then
+  if [ "$(echo "${VERSION}" | awk -F '-' '{print $1}')" -ge 5 ]; then
     if [ -n "${EDGEDB_SERVER_DEFAULT_BRANCH}" ]; then
       server_opts+=(--default-branch="${EDGEDB_SERVER_DEFAULT_BRANCH}")
     fi
@@ -1329,7 +1329,7 @@ edbdocker_run_temp_server() {
       EDGEDB_CLIENT_TLS_SECURITY="insecure"
     )
 
-    if [ $(echo ${VERSION} | awk -F '-' '{print $1}') -lt 5 ]; then
+    if [ "$(echo "${VERSION}" | awk -F '-' '{print $1}')" -lt 5 ]; then
       conn_opts+=(
         EDGEDB_DATABASE="$EDGEDB_SERVER_DATABASE"
       )

--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -560,7 +560,7 @@ edbdocker_setup_env() {
   edbdocker_lookup_env_var "EDGEDB_SERVER_COMPILER_POOL_MODE"
   edbdocker_lookup_env_var "EDGEDB_SERVER_COMPILER_POOL_SIZE"
 
-  if [ "${VERSION}" -ge 5 ]; then
+  if [ $(echo ${VERSION} | awk -F '-' '{print $1}') -ge 5 ]; then
     if [ -n "${EDGEDB_SERVER_DATABASE}" ]; then
       if [ -n "${EDGEDB_SERVER_DEFAULT_BRANCH}" ]; then
         edbdocker_die "ERROR: EDGEDB_SERVER_DATABASE and EDGEDB_SERVER_DEFAULT_BRANCH are mutually exclusive, but both are set"
@@ -1008,7 +1008,7 @@ _edbdocker_bootstrap_cb() {
 
   _edbdocker_print_last_generated_cert_if_needed "$status"
 
-  if [ "${VERSION}" -lt 5 ]; then
+  if [ $(echo ${VERSION} | awk -F '-' '{print $1}') -lt 5 ]; then
     if [ "${EDGEDB_SERVER_DATABASE}" != "edgedb" ]; then
       echo "CREATE DATABASE \`${EDGEDB_SERVER_DATABASE}\`;" \
         | edbdocker_cli "${conn_opts[@]}" -- --database="edgedb"
@@ -1261,7 +1261,7 @@ edbdocker_run_temp_server() {
     server_opts+=(--tls-key-file="${EDGEDB_SERVER_TLS_KEY_FILE}")
   fi
 
-  if [ "${VERSION}" -ge 5 ]; then
+  if [ $(echo ${VERSION} | awk -F '-' '{print $1}') -ge 5 ]; then
     if [ -n "${EDGEDB_SERVER_DEFAULT_BRANCH}" ]; then
       server_opts+=(--default-branch="${EDGEDB_SERVER_DEFAULT_BRANCH}")
     fi
@@ -1329,7 +1329,7 @@ edbdocker_run_temp_server() {
       EDGEDB_CLIENT_TLS_SECURITY="insecure"
     )
 
-    if [ "${VERSION}" -lt 5 ]; then
+    if [ $(echo ${VERSION} | awk -F '-' '{print $1}') -lt 5 ]; then
       conn_opts+=(
         EDGEDB_DATABASE="$EDGEDB_SERVER_DATABASE"
       )

--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -377,12 +377,6 @@ edbdocker_run_server() {
     server_args+=(--tenant-id="${EDGEDB_SERVER_TENANT_ID}")
   fi
 
-  if [ "${VERSION}" -ge 5 ]; then
-    if [ -n "${EDGEDB_SERVER_DEFAULT_BRANCH}" ]; then
-      server_args+=(--default-branch="${EDGEDB_SERVER_DEFAULT_BRANCH}")
-    fi
-  fi
-
   server_args+=( "${_EDGEDB_DOCKER_CMDLINE_ARGS[@]}" )
 
   status_file="$(edbdocker_mktemp_for_server)"
@@ -1267,6 +1261,12 @@ edbdocker_run_temp_server() {
     server_opts+=(--tls-key-file="${EDGEDB_SERVER_TLS_KEY_FILE}")
   fi
 
+  if [ "${VERSION}" -ge 5 ]; then
+    if [ -n "${EDGEDB_SERVER_DEFAULT_BRANCH}" ]; then
+      server_opts+=(--default-branch="${EDGEDB_SERVER_DEFAULT_BRANCH}")
+    fi
+  fi
+
   if edbdocker_server_supports "--compiler-pool-mode"; then
     server_opts+=(--compiler-pool-mode="on_demand")
   fi
@@ -1329,11 +1329,7 @@ edbdocker_run_temp_server() {
       EDGEDB_CLIENT_TLS_SECURITY="insecure"
     )
 
-    if [ "${VERSION}" -ge 5 ]; then
-      conn_opts+=(
-        EDGEDB_BRANCH="${EDGEDB_SERVER_DEFAULT_BRANCH}"
-      )
-    else
+    if [ "${VERSION}" -lt 5 ]; then
       conn_opts+=(
         EDGEDB_DATABASE="$EDGEDB_SERVER_DATABASE"
       )

--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -51,6 +51,10 @@ _EDGEDB_DOCKER_CMDLINE_ARGS=()
 # Set by a caller to edbdocker_die() to signal a specific exict code.
 EDGEDB_DOCKER_ABORT_CODE=1
 
+# VERSION was set in Dockerfile, in the format of either a single major version
+# like "5", or a nightly like "6-3762"
+VERSION_MAJOR=$(echo "${VERSION}" | awk -F '-' '{print $1}')
+
 
 edbdocker_parse_args() {
   if [ "${1:0:1}" != '-' ]; then
@@ -560,7 +564,7 @@ edbdocker_setup_env() {
   edbdocker_lookup_env_var "EDGEDB_SERVER_COMPILER_POOL_MODE"
   edbdocker_lookup_env_var "EDGEDB_SERVER_COMPILER_POOL_SIZE"
 
-  if [ "$(echo "${VERSION}" | awk -F '-' '{print $1}')" -ge 5 ]; then
+  if [ "${VERSION_MAJOR}" -ge 5 ]; then
     if [ -n "${EDGEDB_SERVER_DATABASE}" ]; then
       if [ -n "${EDGEDB_SERVER_DEFAULT_BRANCH}" ]; then
         edbdocker_die "ERROR: EDGEDB_SERVER_DATABASE and EDGEDB_SERVER_DEFAULT_BRANCH are mutually exclusive, but both are set"
@@ -584,7 +588,7 @@ edbdocker_setup_env() {
       msg=(
         "======================================================="
         "WARNING: EDGEDB_SERVER_DEFAULT_BRANCH is ignored"
-        "         because it's for 5.0 and above."
+        "         on server versions prior to 5.0."
         "======================================================="
       )
       edbdocker_log_at_level "warning" "${msg[@]}"
@@ -1008,7 +1012,7 @@ _edbdocker_bootstrap_cb() {
 
   _edbdocker_print_last_generated_cert_if_needed "$status"
 
-  if [ "$(echo "${VERSION}" | awk -F '-' '{print $1}')" -lt 5 ]; then
+  if [ "${VERSION_MAJOR}" -lt 5 ]; then
     if [ "${EDGEDB_SERVER_DATABASE}" != "edgedb" ]; then
       echo "CREATE DATABASE \`${EDGEDB_SERVER_DATABASE}\`;" \
         | edbdocker_cli "${conn_opts[@]}" -- --database="edgedb"
@@ -1261,7 +1265,7 @@ edbdocker_run_temp_server() {
     server_opts+=(--tls-key-file="${EDGEDB_SERVER_TLS_KEY_FILE}")
   fi
 
-  if [ "$(echo "${VERSION}" | awk -F '-' '{print $1}')" -ge 5 ]; then
+  if [ "${VERSION_MAJOR}" -ge 5 ]; then
     if [ -n "${EDGEDB_SERVER_DEFAULT_BRANCH}" ]; then
       server_opts+=(--default-branch="${EDGEDB_SERVER_DEFAULT_BRANCH}")
     fi
@@ -1329,7 +1333,7 @@ edbdocker_run_temp_server() {
       EDGEDB_CLIENT_TLS_SECURITY="insecure"
     )
 
-    if [ "$(echo "${VERSION}" | awk -F '-' '{print $1}')" -lt 5 ]; then
+    if [ "${VERSION_MAJOR}" -lt 5 ]; then
       conn_opts+=(
         EDGEDB_DATABASE="$EDGEDB_SERVER_DATABASE"
       )

--- a/tests/auth.bats
+++ b/tests/auth.bats
@@ -89,6 +89,18 @@ teardown() {
   [[ ${lines[-1]} = '"hello"' ]]
 }
 
+@test "custom default branch" {
+  local container_id
+  local instance
+
+  create_instance container_id instance '{}' \
+    --env=EDGEDB_SERVER_DEFAULT_BRANCH=hello
+
+  run edgedb -I "${instance}" query "SELECT sys::get_current_database()"
+  echo "${lines[@]}"
+  [[ ${lines[-1]} = '"hello"' ]]
+}
+
 @test "tls in env vars" {
   local container_id
   local instance


### PR DESCRIPTION
For prior-5.0 servers, `EDGEDB_SERVER_DEFAULT_BRANCH` is ignored with a warning.

For 5.0 and above, `EDGEDB_SERVER_DEFAULT_BRANCH` is preferred but `EDGEDB_SERVER_DATABASE` is also accepted with a deprecation warning.