### PR TITLE
Update extension installation method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ export DEBIAN_FRONTEND=noninteractive; \
     && s=0 && break || s=$?; done; exit $s \
 ) \
 && ln -s /usr/bin/${package}-${version} /usr/bin/${package} \
-&& apt-get remove -y apt-utils gnupg dirmngr wget apt-transport-https \
+&& apt-get remove -y gnupg dirmngr wget apt-transport-https \
 && apt-get purge -y --auto-remove \
 && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ export DEBIAN_FRONTEND=noninteractive; \
     server=gel-server-${version}; \
     [ -n "${exact_version}" ] && server+="=${exact_version}+*"; \
     for i in $(seq 1 5); do [ $i -gt 1 ] && sleep 1; \
-        env apt-get install -y "${server}" "${server}-ext-postgis" gel-cli \
+        env apt-get install -y "${server}" gel-cli \
     && s=0 && break || s=$?; done; exit $s \
 ) \
 && ln -s /usr/bin/${package}-${version} /usr/bin/${package} \

--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -843,7 +843,7 @@ edbdocker_ensure_packages() {
 
   # Exit early if all packages are already installed
   for extension in "${extensions[@]}"; do
-    if ! dpkg -s gel-server-${VERSION}-ext-${extension} > /dev/null 2>&1; then
+    if ! dpkg -s "gel-server-${VERSION}-ext-${extension}" > /dev/null 2>&1; then
       extensions_to_install+=("${extension}")
     fi
   done
@@ -855,7 +855,7 @@ edbdocker_ensure_packages() {
   edbdocker_log_at_level "info" "Updating package lists to install extensions..."
   s=0
   for i in $(seq 1 5); do 
-    [ $i -gt 1 ] && sleep 1;
+    [ "$i" -gt 1 ] && sleep 1;
     apt-get update > /dev/null 2>&1 && break || s=$?; 
   done
   if [ "$s" -ne 0 ]; then
@@ -865,11 +865,11 @@ edbdocker_ensure_packages() {
   for extension in "${extensions_to_install[@]}"; do
     edbdocker_log_at_level "info" "Installing extension: ${extension}..."
     for i in $(seq 1 5); do
-      [ $i -gt 1 ] && sleep 1;
-      apt-get install -y --no-install-recommends gel-server-${VERSION}-ext-${extension} > /dev/null 2>&1 && break || s=$?;
+      [ "$i" -gt 1 ] && sleep 1;
+      apt-get install -y --no-install-recommends "gel-server-${VERSION}-ext-${extension}" > /dev/null 2>&1 && break || s=$?;
     done
     if [ "$s" -ne 0 ]; then
-      extensions=$(apt-cache search gel-server-${VERSION}-ext- 2>&1 | sed "s/gel-server-${VERSION}-ext-/  /g")
+      extension_list=$(apt-cache search "gel-server-${VERSION}-ext-" 2>&1 | sed "s/gel-server-${VERSION}-ext-/  /g")
       msg=(
         "================================================================"
         "                           ERROR                                "
@@ -881,7 +881,7 @@ edbdocker_ensure_packages() {
         "                                                                "
         "Available extensions:                                           "
         "                                                                "
-        "${extensions}"
+        "${extension_list}"
       )
       edbdocker_die "${msg[@]}"
     fi

--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -886,6 +886,9 @@ edbdocker_ensure_packages() {
       edbdocker_die "${msg[@]}"
     fi
   done
+
+  (apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*) > /dev/null 2>&1
 }
 
 

--- a/docker-entrypoint-funcs.sh
+++ b/docker-entrypoint-funcs.sh
@@ -268,6 +268,7 @@ edbdocker_prepare() {
   edbdocker_run_entrypoint_parts
   edbdocker_setup_env
   edbdocker_ensure_dirs
+  edbdocker_ensure_packages
 }
 
 
@@ -446,6 +447,7 @@ edbdocker_setup_env() {
   : "${GEL_SERVER_COMPILER_POOL_SIZE:=}"
   : "${GEL_SERVER_TENANT_ID:=${EDGEDB_SERVER_TENANT_ID:-}}"
   : "${GEL_SERVER_RUNSTATE_DIR:=${EDGEDB_SERVER_RUNSTATE_DIR:-}}"
+  : "${GEL_DOCKER_EXTENSIONS:=${EDGEDB_DOCKER_EXTENSIONS:-}}"
 
   if [ -z "${GEL_SERVER_UID:-}" ]; then
     if [ "$(id -u)" = "0" ]; then
@@ -831,6 +833,59 @@ edbdocker_ensure_dirs() {
   if [ "$(id -u)" = "0" ]; then
     chown -R "${GEL_SERVER_UID}" "${GEL_SERVER_RUNSTATE_DIR}"
   fi
+}
+
+
+edbdocker_ensure_packages() {
+  IFS=',' read -ra extensions <<< "$GEL_DOCKER_EXTENSIONS"
+  
+  extensions_to_install=()
+
+  # Exit early if all packages are already installed
+  for extension in "${extensions[@]}"; do
+    if ! dpkg -s gel-server-${VERSION}-ext-${extension} > /dev/null 2>&1; then
+      extensions_to_install+=("${extension}")
+    fi
+  done
+
+  if [ "${#extensions_to_install[@]}" -eq 0 ]; then
+    return
+  fi
+
+  edbdocker_log_at_level "info" "Updating package lists to install extensions..."
+  s=0
+  for i in $(seq 1 5); do 
+    [ $i -gt 1 ] && sleep 1;
+    apt-get update > /dev/null 2>&1 && break || s=$?; 
+  done
+  if [ "$s" -ne 0 ]; then
+    edbdocker_die "Failed to update package lists"
+  fi
+
+  for extension in "${extensions_to_install[@]}"; do
+    edbdocker_log_at_level "info" "Installing extension: ${extension}..."
+    for i in $(seq 1 5); do
+      [ $i -gt 1 ] && sleep 1;
+      apt-get install -y --no-install-recommends gel-server-${VERSION}-ext-${extension} > /dev/null 2>&1 && break || s=$?;
+    done
+    if [ "$s" -ne 0 ]; then
+      extensions=$(apt-cache search gel-server-${VERSION}-ext- 2>&1 | sed "s/gel-server-${VERSION}-ext-/  /g")
+      msg=(
+        "================================================================"
+        "                           ERROR                                "
+        "                           -----                                "
+        "                                                                "
+        "Failed to install extension: ${extension}                       "
+        "                                                                "
+        "Please check the extension name and try again.                  "
+        "                                                                "
+        "Available extensions:                                           "
+        "                                                                "
+        "${extensions}"
+      )
+      edbdocker_die "${msg[@]}"
+    fi
+  done
 }
 
 

--- a/tests/schema_extension.bats
+++ b/tests/schema_extension.bats
@@ -2,7 +2,7 @@ load testbase
 
 setup() {
   build_container
-  docker build -e GEL_DOCKER_EXTENSIONS="postgis" -t gel-test:schema-extension tests/schema_with_extension
+  docker build -t gel-test:schema-extension tests/schema_with_extension
 }
 
 teardown() {
@@ -13,7 +13,7 @@ teardown() {
   local container_id
   local instance
 
-  create_instance container_id instance '{"image":"gel-test:schema-extension"}'
+  create_instance container_id instance '{"image":"gel-test:schema-extension","extensions":"postgis"}'
 
   # wait until migrations are complete
   sleep 3

--- a/tests/schema_extension.bats
+++ b/tests/schema_extension.bats
@@ -2,7 +2,7 @@ load testbase
 
 setup() {
   build_container
-  docker build -t gel-test:schema-extension tests/schema_with_extension
+  docker build -e GEL_DOCKER_EXTENSIONS="postgis" -t gel-test:schema-extension tests/schema_with_extension
 }
 
 teardown() {

--- a/tests/testbase.bash
+++ b/tests/testbase.bash
@@ -91,6 +91,7 @@ create_instance() {
   password="$(echo $3 | jq -r '.password // ""')"
   database="$(echo $3 | jq -r '.database // ""')"
   tls_ca_file="$(echo $3 | jq -r '.tls_ca_file // ""')"
+  extensions="$(echo $3 | jq -r '.extensions // ""')"
 
   if [ $# -gt 2 ]; then
     shift 3

--- a/tests/testbase.bash
+++ b/tests/testbase.bash
@@ -119,6 +119,11 @@ create_instance() {
       --env=GEL_SERVER_DEFAULT_AUTH_METHOD=Trust
     )
   fi
+  if [ -n "${extensions}" ]; then
+    docker_args+=(
+      --env=GEL_DOCKER_EXTENSIONS="${extensions}"
+    )
+  fi
 
   while [ $# -gt 0 ]; do
     if [ "$1" == "--" ]; then


### PR DESCRIPTION
Allows for bootstrap of a docker container with extensions installed. `GEL_DOCKER_EXTENSIONS` is a comma-separated value, and will attempt to install specified packages from apt using the server's version as a prefix.

If the extensions are already installed, this will not attempt to re-install them (ie: if the user has bootstrapped the extension as part of their own docker build).

Successful run:

```
❯ docker run --rm -e GEL_DOCKER_EXTENSIONS=postgis -e GEL_SERVER_TLS_CERT_MODE=generate_self_signed -e GEL_SERVER_PASSWORD=1234 docker.io/library/gel
Updating package lists to install extensions...
Installing extension: postgis...
Bootstrapping Gel instance on the local volume...
```

Failed run:

```
❯ docker run --rm -e GEL_DOCKER_EXTENSIONS=postgis,foo -e GEL_SERVER_TLS_CERT_MODE=generate_self_signed -e GEL_SERVER_PASSWORD=1234 docker.io/library/gel
Updating package lists to install extensions...
Installing extension: postgis
Installing extension: foo
================================================================
                           ERROR                                
                           -----                                
                                                                
Failed to install extension: foo                       
                                                                
Please check the extension name and try again.                  
                                                                
Available extensions:                                           
                                                                
  postgis - Geographic Objects for EdgeDB
```